### PR TITLE
Caching image thumbnails: bad idea?

### DIFF
--- a/core/src/plugins/editor.diaporama/class.ImagePreviewer.php
+++ b/core/src/plugins/editor.diaporama/class.ImagePreviewer.php
@@ -59,10 +59,10 @@ class ImagePreviewer extends AJXP_Plugin {
 				
 				header("Content-Type: ".AJXP_Utils::getImageMimeType(basename($cId))."; name=\"".basename($cId)."\"");
 				header("Content-Length: ".strlen($data));
-				header('Cache-Control: public');
-                header("Pragma:");
+				header('Cache-Control: no-cache');
+                header("Pragma: no-cache");
                 header("Last-Modified: " . gmdate("D, d M Y H:i:s", time()-10000) . " GMT");
-                header("Expires: " . gmdate("D, d M Y H:i:s", time()+5*24*3600) . " GMT");
+                header("Expires: " . gmdate("D, d M Y H:i:s", time()) . " GMT");
 				print($data);
 
 			}else{
@@ -75,10 +75,10 @@ class ImagePreviewer extends AJXP_Plugin {
                 $filesize = $stat["size"];
 				header("Content-Type: ".AJXP_Utils::getImageMimeType(basename($file))."; name=\"".basename($file)."\"");
 				header("Content-Length: ".$filesize);
-				header('Cache-Control: public');
-                header("Pragma:");
+				header('Cache-Control: no-cache');
+                header("Pragma: no-cache");
                 header("Last-Modified: " . gmdate("D, d M Y H:i:s", time()-10000) . " GMT");
-                header("Expires: " . gmdate("D, d M Y H:i:s", time()+5*24*3600) . " GMT");
+                header("Expires: " . gmdate("D, d M Y H:i:s", time()) . " GMT");
 
 				$class = $streamData["classname"];
 				$stream = fopen("php://output", "a");


### PR DESCRIPTION
Images thumbnails are served as cacheable content (Cache-Control: public) by ImagePreviewer.
So, if an image file is replaced, its thumbnail sometimes still shows previous image thumbnail.
I modified ImagePreviewer class to serve thumbnail as non-cacheable content and it solved this issue, but I don't know if there were a real need to serve thumbnails as cacheable at a first time.
