### PR TITLE
Unable to use WebDAV with NetDrive (4.2.3 branch)

### DIFF
--- a/core/classes/ezc/Webdav/server.php
+++ b/core/classes/ezc/Webdav/server.php
@@ -181,7 +181,9 @@ class ezcWebdavServer
         $this->properties['backend'] = $backend;
         if ( !isset( $_SERVER['HTTP_USER_AGENT'] ) )
         {
-            throw new ezcWebdavMissingHeaderException( 'User-Agent' );
+            // Fake User-Agent for empty User-Agents in order to support Netdrive
+            $_SERVER['HTTP_USER_AGENT'] = "Unknown";
+            //throw new ezcWebdavMissingHeaderException( 'User-Agent' );
         }
         // Configure the server according to the requesting client
         $this->configurations->configure( $this, $_SERVER['HTTP_USER_AGENT'] );


### PR DESCRIPTION
This is not a issue in AjaXplorer, but in bundled WebDAV library and NetDrive, but it is affecting AjaXplorer's WebDAV service.
NetDrive doesn't send an User-Agent header when connecting a WebDAV share but ezWebDAV refuses connections lacking User-Agent header.
Thus, is not possible to connect to WebDAV service using NetDrive.

Proposed patch:

``` udiff
diff --git a/core/classes/ezc/Webdav/server.php b/core/classes/ezc/Webdav/server.php
index 2f5e3e1..281260f 100644
--- a/core/classes/ezc/Webdav/server.php
+++ b/core/classes/ezc/Webdav/server.php
@@ -181,7 +181,9 @@ class ezcWebdavServer
         $this->properties['backend'] = $backend;
         if ( !isset( $_SERVER['HTTP_USER_AGENT'] ) )
         {
-            throw new ezcWebdavMissingHeaderException( 'User-Agent' );
+            // Fake User-Agent for empty User-Agents in order to support Netdrive
+            $_SERVER['HTTP_USER_AGENT'] = "Unknown";
+            //throw new ezcWebdavMissingHeaderException( 'User-Agent' );
         }
         // Configure the server according to the requesting client
         $this->configurations->configure( $this, $_SERVER['HTTP_USER_AGENT'] );
```
