### PR TITLE
Failed to create admin user during bootstrap due to PASSWORD_MINLENGTH

### DIFF
--- a/core/src/core/classes/class.AuthService.php
+++ b/core/src/core/classes/class.AuthService.php
@@ -649,7 +649,7 @@ class AuthService
         if(!ConfService::getCoreConf("ALLOW_GUEST_BROWSING", "auth") && $userId == "guest"){
             throw new Exception("Reserved user id");
         }
-		if(strlen($userPass) < ConfService::getCoreConf("PASSWORD_MINLENGTH", "auth") && $userId != "guest"){
+		if(strlen($userPass) < ConfService::getCoreConf("PASSWORD_MINLENGTH", "auth") && $userId != "guest" && $isAdmin === false){
 			$messages = ConfService::getMessages();
 			throw new Exception($messages[378]);
 		}


### PR DESCRIPTION
On first boot, it tries to create admin user with 'admin' as password, which fails since it is shorter than default PASSWORD_MINLENGTH (8):

```
Fatal error: Uncaught exception 'Exception' with message 'Warning, password is empty or too short!' in /var/www/localhost/htdocs/ajaxplorer/core/src/core/classes/class.AuthService.php:654
```
