### PR TITLE
[4.2.3] WebDAV doesn't work with access.ftp

### DIFF
--- a/plugins/access.ftp/class.ftpAccessWrapper.php
+++ b/plugins/access.ftp/class.ftpAccessWrapper.php
@@ -285,7 +285,7 @@ class ftpAccessWrapper implements AjxpWrapper {
 		else 
 		{			
 			ftp_chdir($link, $serverPath);
-			$contents = ftp_rawlist($link, ".");
+			$contents = ftp_rawlist($link, "-a .");
         	//AJXP_Logger::debug("RAW LIST RESULT ".print_r($contents, true));			
 		}
 		


### PR DESCRIPTION
When trying to use WebDAV with an access.ftp repository I'm getting a 404 response.

This is because, it tries to stat() the directory in core/classes/class.AJXP_WebdavBackend.php to check if it exists:

``` php
    protected function nodeExists( $path ){
        $path = $this->fixPath($path);
        if(isset($this->statCache[$path]["node_exists"])){
            return $this->statCache[$path]["node_exists"];
        }
        $url = $this->getAccessDriver()->getRessourceUrl($path);
        $result = file_exists( $url );
        AJXP_Logger::debug("nodeExists($path, $url): $result");
        $this->statCache[$path]["node_exists"] = $result;
        return $result;     
    }
```

When using an access.ftp repository, what it does is to send a LIST &lt;node&gt; request and check if &lt;node&gt; is among the returned results. But, when &lt;node&gt; is a directory, it will return its contents and not the directory itself.
I've found that this can be fixed by replacing LIST request by LIST -a:

``` udiff
diff --git a/plugins/access.ftp/class.ftpAccessWrapper.php b/plugins/access.ftp/class.ftpAccessWrapper.php
index eed6f94..a1b2cd1 100644
--- a/plugins/access.ftp/class.ftpAccessWrapper.php
+++ b/plugins/access.ftp/class.ftpAccessWrapper.php
@@ -282,7 +282,7 @@ class ftpAccessWrapper {
        else 
        {           
            ftp_chdir($link, $serverPath);
-           $contents = ftp_rawlist($link, ".");
+           $contents = ftp_rawlist($link, "-a .");
            //AJXP_Logger::debug("RAW LIST RESULT ".print_r($contents, true));          
        }

```
