### PR TITLE
 Partially fixed the displaying of hidden files in FTP access plug-in

### DIFF
--- a/core/src/plugins/access.ftp/class.ftpAccessWrapper.php
+++ b/core/src/plugins/access.ftp/class.ftpAccessWrapper.php
@@ -283,8 +283,8 @@ class ftpAccessWrapper implements AjxpWrapper {
 			$parentDir = $this->safeDirname($serverPath);
 			$fileName = $this->safeBasename($serverPath);
 			ftp_chdir($link, $parentDir);
-			$rl_dirlist = @ftp_rawlist($link, ".");
-			//AJXP_Logger::debug("FILE RAWLIST FROM ".$parentDir);
+			$rl_dirlist = @ftp_rawlist($link, (ConfService::getRepositoryById($this->repositoryId)->getOption("SHOW_HIDDEN_FILES") ? "-A ." : "."));
+			AJXP_Logger::debug("FILE RAWLIST FROM ".$parentDir);
 			if (is_array($rl_dirlist)){
                 $escaped = preg_quote($fileName);
 				foreach($rl_dirlist as $rl_index => $rl_entry){
@@ -297,8 +297,8 @@ class ftpAccessWrapper implements AjxpWrapper {
 		else 
 		{			
 			ftp_chdir($link, $serverPath);
-			$contents = ftp_rawlist($link, ".");
-        	//AJXP_Logger::debug("RAW LIST RESULT ".print_r($contents, true));			
+			$contents = ftp_rawlist($link, (ConfService::getRepositoryById($this->repositoryId)->getOption("SHOW_HIDDEN_FILES") ? "-A ." : "."));
+			AJXP_Logger::debug("RAW LIST RESULT ".print_r($contents, true));			
 		}
 		
         if (!is_array($contents) && !$this->ftpActive) 


### PR DESCRIPTION
Hello,

It'll show hidden files, if defined as true in conf/bootstrap_repositories.php of the repository's DRIVER_OPTIONS array, but does not work if defined in plugin-config (eg data/plugins/conf.serial/plugins_configs.ser).
## 

Best regards,
Günter Kits 
