### PR TITLE
Deny login to deleted users in master/slave mode

### DIFF
--- a/core/src/plugins/auth.multi/class.multiAuthDriver.php
+++ b/core/src/plugins/auth.multi/class.multiAuthDriver.php
@@ -299,14 +299,27 @@ class multiAuthDriver extends AbstractAuthDriver {
                         $this->drivers[$this->slaveName]->changePassword($login, $pass);
                     }else{
                         $this->drivers[$this->slaveName]->createUser($login, $pass);
+                        $confDriver = ConfService::getConfStorageImpl();
+                        $userObject = $confDriver->createUserObject($login);
+                        $userObject->personalRole->setParameterValue("auth.core", "auth_scheme", "master");
+                        $userObject->save();
                     }
+
                     return true;
                 }else{
                     return false;
                 }
             }else{
-                $res = $this->drivers[$this->slaveName]->checkPassword($login, $pass, $seed);
-                return $res;
+                // only allow auth from slave plugin if the user hasn't been created
+                // from the master auth plugin
+                if ($this->drivers[$this->slaveName]->checkPassword($login, $pass, $seed)){
+                    $confDriver = ConfService::getConfStorageImpl();
+                    $userObject = $confDriver->createUserObject($login);
+                    $param = $userObject->personalRole->filterParameterValue("auth.core", "auth_scheme", AJXP_REPO_SCOPE_ALL, "");
+                    return ($param != "master");
+                }else{
+                    return false;
+                }
             }
         }
 

--- a/core/src/plugins/core.auth/manifest.xml
+++ b/core/src/plugins/core.auth/manifest.xml
@@ -7,6 +7,7 @@
         </resources>
     </client_settings>
 	<server_settings>
+		<param name="auth_scheme" scope="user" description="The authentication scheme that the user has been created with" label="Authentication scheme" type="string" expose="false"/>
 		<global_param name="ENABLE_USERS" group="CONF_MESSAGE[Generic Auth Features]"  type="boolean" label="CONF_MESSAGE[Enable Users]" description="CONF_MESSAGE[Activate the users management system to protect your AjaXplorer installation.]" mandatory="true" default="true"/>
 		<global_param name="CASE_SENSITIVE" group="CONF_MESSAGE[Generic Auth Features]"  type="boolean" label="CONF_MESSAGE[Case Sensitive]" description="CONF_MESSAGE[Whether the users identifiers should be case sensitive or not]" mandatory="true" default="true"/>
 		<global_param name="ALLOW_GUEST_BROWSING" group="CONF_MESSAGE[Generic Auth Features]"  type="boolean" label="CONF_MESSAGE[Guest Browsing]" description="CONF_MESSAGE[Enable the 'guest' user, who does not need to log in.]" mandatory="true" default="false"/>


### PR DESCRIPTION
Do not allow authentication throught the slave auth plugin if the
user has been created by authenticating to the master auth plugin.

fixes #38
