### PR TITLE
auth.cas type mismatch for server port parameter

### DIFF
--- a/core/src/plugins/auth.cas/manifest.xml
+++ b/core/src/plugins/auth.cas/manifest.xml
@@ -13,7 +13,7 @@
   </client_settings>
   <server_settings>
     <param name="CAS_SERVER" type="string" label="CONF_MESSAGE[CAS Server]" description="CONF_MESSAGE[CAS server address]" mandatory="true" />
-    <param name="CAS_PORT" type="string" label="CONF_MESSAGE[CAS Port]" description="CONF_MESSAGE[Port where CAS server is running on]" mandatory="true" />
+    <param name="CAS_PORT" type="integer" label="CONF_MESSAGE[CAS Port]" description="CONF_MESSAGE[Port where CAS server is running on]" mandatory="true" />
     <param name="CAS_URI" type="string" label="CONF_MESSAGE[CAS URI]" description="CONF_MESSAGE[URI for CAS service]" mandatory="false" />
     <param name="LOGOUT_URL" type="string" label="CONF_MESSAGE[Logout URL]" description="CONF_MESSAGE[Redirect to the given URL on loggin out]" mandatory="false" />
     <param name="USERS_FILEPATH" type="string" label="CONF_MESSAGE[Users]" description="CONF_MESSAGE[The users list]" mandatory="true"/>


### PR DESCRIPTION
If auth.cas is configured using new configuration interface which replaces modifying configuration files, it will fail because phpCAS library expects server port to be an integer but it receives a string:

phpCAS error: phpCAS::client(): type mismatched for parameter $server_port (should be `integer') in /var/www/localhost/htdocs/ajaxplorer/core/src/plugins/auth.cas/class.casAuthDriver.php on line 42
