### PR TITLE
Redeclared class when create_repository is called twice

### DIFF
--- a/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
+++ b/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
@@ -894,8 +894,9 @@ class ajxp_confAccessDriver extends AbstractAccessDriver
 					if(!$isTemplate && is_file($testFile))
 					{
 					    //chdir(AJXP_TESTS_FOLDER."/plugins");
-						include($testFile);
 						$className = $newRep->getAccessType()."AccessTest";
+						if (!class_exists($className))
+							include($testFile);
 						$class = new $className();
 						$result = $class->doRepositoryTest($newRep);
 						if(!$result){


### PR DESCRIPTION
I've made a PHP script that calls AjaXplorer functions to do a mass importing of a lot of users and repositories, so it calls create_group and create_user many times.
I've found that every time create_repository is called it tries to load AccessTest class either it has already been loaded or not, so if two repositories of the same type exist, it will fail because of redeclared classes:

```
PHP Fatal error:  Cannot redeclare class fsAccessTest in /var/www/localhost/htdocs/ajaxplorer/core/src/plugins/access.fs/test.fsAccess.php on line 57
```

I don't know if AjaXplorer is intended to be used the way I'm using it in this script and if there is any intention to support this kind of usage, but I think that fixing this is quite simple, just adding an "if (class_exists(..." before the include will work, see attached pull request below.

Here is a proof of concept:

``` php
<?php
// Admin username
$admin = "admin";

// AjaXplorer initialization
include_once("base.conf.php");
require_once("plugins/core.log/class.AJXP_Logger.php");
$pServ = AJXP_PluginsService::getInstance();
ConfService::init();
$confPlugin = ConfService::getInstance()->confPluginSoftLoad($pServ);
$pServ->loadPluginsRegistry(AJXP_INSTALL_PATH."/plugins", $confPlugin);
ConfService::start();

$conf = ConfService::getConfStorageImpl();
require_once($conf->getUserClassFileName());
session_name("AjaXplorer");
session_start();

// Login as admin user
AuthService::logUser($admin, "", true, false);

$loggedUser = AuthService::getLoggedUser();
if (empty($loggedUser)) die("Can't login as admin user");

ConfService::switchRootDir("ajxp_conf");

ConfService::loadRepositoryDriver();
AJXP_PluginsService::getInstance()->initActivePlugins();

// Proof of concept
function create_repo($repo_name)
{
  AJXP_Controller::findActionAndApply("edit",
    array(
      "secure_token"                       => AuthService::generateSecureToken(),
      "get_action"                         => "edit",
      "sub_action"                         => "create_repository",
      "DISPLAY"                            => $repo_name,
      "DRIVER"                             => "fs",
      "DRIVER_OPTION_PATH"                 => "/tmp/ajaxplorer/$repo_name",
      "DRIVER_OPTION_CREATE"               => true,
      "DRIVER_OPTION_CHMOD_VALUE"          => 0666,
      "DRIVER_OPTION_RECYCLE_BIN"          => "recycle_bin",
      "DRIVER_OPTION_CHARSET"              => "",
      "DRIVER_OPTION_PAGINATION_THRESHOLD" => "500",
      "DRIVER_OPTION_PAGINATION_NUMBER"    => "200",
      "AJXP_SLUG"                          => $repo_name,
      "DRIVER_OPTION_DEFAULT_RIGHTS"       => ""
    ), array()
  );
}

create_repo("test1");
create_repo("test2");
```
