### PR TITLE
Typo in core/src/plugins/conf.sql/create.sql

### DIFF
--- a/core/src/plugins/conf.sql/create.sql
+++ b/core/src/plugins/conf.sql/create.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS ajxp_users (
   password varchar(255) NOT NULL,
   groupPath varchar(255) NULL,
   PRIMARY KEY  (login)
-)
+);
 
 CREATE TABLE IF NOT EXISTS ajxp_user_rights (
 	rid INTEGER PRIMARY KEY AUTO_INCREMENT, 


### PR DESCRIPTION
Missing ';' after first CREATE statement.
