### PR TITLE
Query sorted repositories list.

### DIFF
--- a/core/src/plugins/conf.sql/class.sqlConfDriver.php
+++ b/core/src/plugins/conf.sql/class.sqlConfDriver.php
@@ -192,7 +192,7 @@ class sqlConfDriver extends AbstractConfDriver {
             $acls = $user->mergedRole->listAcls();
             $limitRepositories = array_keys($acls);
             foreach($limitRepositories as $i => $k) $limitRepositories[$i] = "'$k'";
-            $query = 'SELECT * FROM [ajxp_repo] WHERE uuid IN ('.implode(",",$limitRepositories).' ORDER BY [display] ASC)';
+            $query = 'SELECT * FROM [ajxp_repo] WHERE uuid IN ('.implode(",",$limitRepositories).') ORDER BY [display] ASC';
         }else{
             $query = 'SELECT * FROM [ajxp_repo] ORDER BY [display] ASC';
         }


### PR DESCRIPTION
When using conf.sql, repositories appear unsorted in ACL tab, so it can be quite painful to find a repository if you have a lot of them.

This can be fixed by adding an ORDER clause to SELECT statement.
