### PR TITLE
conf.sql: duplication with groups named with substrings of other group names

### DIFF
--- a/core/src/plugins/conf.sql/class.sqlConfDriver.php
+++ b/core/src/plugins/conf.sql/class.sqlConfDriver.php
@@ -536,7 +536,7 @@ class sqlConfDriver extends AbstractConfDriver {
      * @return string[]
      */
     function getChildrenGroups($baseGroup = "/"){
-        $res = dibi::query("SELECT * FROM [ajxp_groups] WHERE [groupPath] LIKE %s", $baseGroup."%");
+        $res = dibi::query("SELECT * FROM [ajxp_groups] WHERE [groupPath] LIKE %s", $baseGroup . (preg_match("-/$-", $baseGroup)? "":"/") . "%");
         $pairs = $res->fetchPairs("groupPath", "groupLabel");
         foreach($pairs as $path => $label){
             if(strlen($path) <= strlen($baseGroup)) unset($pairs[$path]);


### PR DESCRIPTION
I've found that if you create a group that contains a dash and then at the same level another one that has the same name but removing everything from the dash, the first one appears both at the same level as the second one and as a subgroup of the second one.

For example, we create 'testgroup', 'testgroup-1' and 'testgroup-2'.
'testgroup-1' and 'testgroup-2' will appear both at the same level as 'testgroup' and also as subgroups of 'testgroup'. This last is wrong and only happens with conf.sql, not with conf.serial.

http://img841.imageshack.us/img841/6494/ajxpgroups.png

The duplicated groups behave as different groups and you can create different users in each one:

```
mysql> select login, groupPath from ajxp_users;
+------------------+------------------------+
| login            | groupPath              |
+------------------+------------------------+
| admin            | /                      |
| user-testgroup-1 | /testgroup-1           |
| user-testgroup-2 | /testgroup/testgroup-2 |
+------------------+------------------------+
```

But you can't delete the subgroups as they don't really exist:

```
mysql> select groupPath from ajxp_groups;
+--------------+
| groupPath    |
+--------------+
| /testgroup   |
| /testgroup-1 |
| /testgroup-2 |
+--------------+
```
