### PR TITLE
Logging full path with repository slug in file transfers

### DIFF
--- a/core/src/core/classes/sabredav/lib/Sabre/DAV/Server.php
+++ b/core/src/core/classes/sabredav/lib/Sabre/DAV/Server.php
@@ -644,7 +644,8 @@ class Server {
             $this->httpResponse->sendBody($body);
 
         }
-        \AJXP_Logger::logAction("Download", array("files"=>$node->getUrl()));
+        $repositories = \ConfService::getRepositoriesList("user");
+        \AJXP_Logger::logAction("Download", array("files"=>$repositories[\ConfService::getCurrentRepositoryId()]->getSlug()."/".$uri));
 
     }
 
@@ -905,7 +906,8 @@ class Server {
             $this->httpResponse->sendStatus(201);
 
         }
-        \AJXP_Logger::logAction("Upload", array("files"=>$node->getUrl()));
+        $repositories = \ConfService::getRepositoriesList("user");
+        \AJXP_Logger::logAction("Upload", array("files"=>$repositories[\ConfService::getCurrentRepositoryId()]->getSlug()."/".$uri));
 
     }
 

--- a/core/src/plugins/access.fs/class.fsAccessDriver.php
+++ b/core/src/plugins/access.fs/class.fsAccessDriver.php
@@ -142,6 +142,27 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
         return array("REMOVE" => array(), "ADD" => array(), "UPDATE" => array());
     }
 	
+	public function addSlugToPath($selection)
+	{
+		if (is_array($selection))
+			// As passed by Copy/Move
+			$orig_files = $selection;
+		elseif ((is_object($selection)) && (isset($selection->files)) && (is_array($selection->files)))
+			// As passed by Download
+			$orig_files = $selection->files;
+		elseif (is_string($selection))
+			// As passed by destination parameter
+			return $this->repository->slug.$selection;
+		else
+			// Unrecognized
+			return $selection;
+
+		$files = array();
+		foreach ($orig_files as $file)
+			$files[] = $this->repository->slug.$file;
+		return $files;
+	}
+
 	function switchAction($action, $httpVars, $fileVars){
 		if(!isSet($this->actions[$action])) return;
 		parent::accessPreprocess($action, $httpVars, $fileVars);
@@ -181,7 +202,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 			//	DOWNLOAD
 			//------------------------------------
 			case "download":
-				AJXP_Logger::logAction("Download", array("files"=>$selection));
+				AJXP_Logger::logAction("Download", array("files"=>$this->addSlugToPath($selection)));
 				@set_error_handler(array("HTMLWriter", "javascriptErrorHandler"), E_ALL & ~ E_NOTICE);
 				@register_shutdown_function("restore_error_handler");
 				$zip = false;
@@ -315,7 +336,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 			case "get_content":
 					
 				$dlFile = $this->urlBase.$selection->getUniqueFile();
-                AJXP_Logger::logAction("Get_content", array("files"=>$selection));
+				AJXP_Logger::logAction("Get_content", array("files"=>$this->addSlugToPath($selection)));
 				if(AJXP_Utils::getStreamingMimeType(basename($dlFile))!==false){
 					$this->readFile($this->urlBase.$selection->getUniqueFile(), "stream_content");					
 				}else{
@@ -331,7 +352,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 				// Load "code" variable directly from POST array, do not "securePath" or "sanitize"...
 				$code = $httpVars["content"];
 				$file = $selection->getUniqueFile($httpVars["file"]);
-				AJXP_Logger::logAction("Online Edition", array("file"=>$file));
+				AJXP_Logger::logAction("Online Edition", array("file"=>$this->addSlugToPath($file)));
 				if(isSet($httpVars["encode"]) && $httpVars["encode"] == "base64"){
 				    $code = base64_decode($code);
 				}else{
@@ -395,9 +416,9 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                     if(isSet($httpVars["force_copy_delete"])){
                         $errorMessage = $this->delete($selection->getFiles(), $logMessages);
                         if($errorMessage) throw new AJXP_Exception(SystemTextEncoding::toUTF8($errorMessage));
-                        AJXP_Logger::logAction("Copy/Delete", array("files"=>$selection, "destination" => $dest));
+                        AJXP_Logger::logAction("Copy/Delete", array("files"=>$this->addSlugToPath($selection), "destination" => $this->addSlugToPath($dest)));
                     }else{
-                        AJXP_Logger::logAction(($action=="move"?"Move":"Copy"), array("files"=>$selection, "destination"=>$dest));
+                        AJXP_Logger::logAction(($action=="move"?"Move":"Copy"), array("files"=>$this->addSlugToPath($selection), "destination"=>$this->addSlugToPath($dest)));
                     }
                     $logMessage = join("\n", $success);
 				}
@@ -432,7 +453,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 					$logMessage = join("\n", $logMessages);
 				}
 				if($errorMessage) throw new AJXP_Exception(SystemTextEncoding::toUTF8($errorMessage));
-				AJXP_Logger::logAction("Delete", array("files"=>$selection));
+				AJXP_Logger::logAction("Delete", array("files"=>$this->addSlugToPath($selection)));
                 if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
                 $nodesDiffs["REMOVE"] = array_merge($nodesDiffs["REMOVE"], $selection->getFiles());
 				
@@ -467,10 +488,10 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 				$logMessage= SystemTextEncoding::toUTF8($file)." $mess[41] ".SystemTextEncoding::toUTF8($filename_new);
 				//$reloadContextNode = true;
 				//$pendingSelection = $filename_new;
-                if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
-                if($dest == null) $dest = dirname($file);
-                $nodesDiffs["UPDATE"][$file] = new AJXP_Node($this->urlBase.$dest."/".$filename_new);
-				AJXP_Logger::logAction("Rename", array("original"=>$file, "new"=>$filename_new));
+				if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
+				if($dest == null) $dest = dirname($file);
+				$nodesDiffs["UPDATE"][$file] = new AJXP_Node($this->urlBase.$dest."/".$filename_new);
+				AJXP_Logger::logAction("Rename", array("original"=>$this->addSlugToPath($file), "new"=>$filename_new));
 				
 			break;
 		
@@ -496,7 +517,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                 $newNode = new AJXP_Node($this->urlBase.$dir."/".$dirname);
                 if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
                 array_push($nodesDiffs["ADD"], $newNode);
-                AJXP_Logger::logAction("Create Dir", array("dir"=>$dir."/".$dirname));
+                AJXP_Logger::logAction("Create Dir", array("dir"=>$this->addSlugToPath($dir)."/".$dirname));
 
 			break;
 		
@@ -522,7 +543,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 				$logMessage = $messtmp;
 				//$reloadContextNode = true;
 				//$pendingSelection = $dir."/".$filename;
-				AJXP_Logger::logAction("Create File", array("file"=>$dir."/".$filename));
+				AJXP_Logger::logAction("Create File", array("file"=>$this->addSlugToPath($dir)."/".$filename));
 				$newNode = new AJXP_Node($this->urlBase.$dir."/".$filename);
                 if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
                 array_push($nodesDiffs["ADD"], $newNode);
@@ -548,7 +569,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 				}
 				//$messtmp.="$mess[34] ".SystemTextEncoding::toUTF8($filename)." $mess[39] ";
 				$logMessage="Successfully changed permission to ".$chmod_value." for ".count($changedFiles)." files or folders";
-                AJXP_Logger::logAction("Chmod", array("dir"=>$dir, "filesCount"=>count($changedFiles)));
+                AJXP_Logger::logAction("Chmod", array("dir"=>$this->addSlugToPath($dir), "filesCount"=>count($changedFiles)));
                 if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
                 $nodesDiffs["UPDATE"] = array_merge($nodesDiffs["UPDATE"], $selection->buildNodes($this));
 
@@ -561,12 +582,12 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 
 				AJXP_Logger::debug("Upload Files Data", $fileVars);
 				$destination=$this->urlBase.AJXP_Utils::decodeSecureMagic($dir);
-				AJXP_Logger::debug("Upload inside", array("destination"=>$destination));
+				AJXP_Logger::debug("Upload inside", array("destination"=>$this->addSlugToPath($destination)));
 				if(!$this->isWriteable($destination))
 				{
 					$errorCode = 412;
 					$errorMessage = "$mess[38] ".SystemTextEncoding::toUTF8($dir)." $mess[99].";
-					AJXP_Logger::debug("Upload error 412", array("destination"=>$destination));
+					AJXP_Logger::debug("Upload error 412", array("destination"=>$this->addSlugToPath($destination)));
 					return array("ERROR" => array("CODE" => $errorCode, "MESSAGE" => $errorMessage));
 				}
 				foreach ($fileVars as $boxName => $boxData)
@@ -657,10 +678,10 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                     }
 
 					$this->changeMode($destination."/".$userfile_name);
-                    $createdNode = new AJXP_Node($destination."/".$userfile_name);
-                    //AJXP_Controller::applyHook("node.change", array(null, $createdNode, false));
+					$createdNode = new AJXP_Node($destination."/".$userfile_name);
+					//AJXP_Controller::applyHook("node.change", array(null, $createdNode, false));
 					$logMessage.="$mess[34] ".SystemTextEncoding::toUTF8($userfile_name)." $mess[35] $dir";
-					AJXP_Logger::logAction("Upload File", array("file"=>SystemTextEncoding::fromUTF8($dir)."/".$userfile_name));
+					AJXP_Logger::logAction("Upload File", array("file"=>$this->addSlugToPath(SystemTextEncoding::fromUTF8($dir))."/".$userfile_name));
 				}
 
 				if(isSet($errorMessage)){
@@ -1330,9 +1351,9 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 				}
 			}
 		}
-		AJXP_Logger::debug("Archive", $files);
+		AJXP_Logger::debug("Archive", $this->addSlugToPath($files));
 		$realDestination = call_user_func(array($this->wrapperClassName, "getRealFSReference"), $this->urlBase.$destDir);
-		AJXP_Logger::debug("Extract", array($realDestination, $realZipFile, $files, $zipLocalPath));
+		AJXP_Logger::debug("Extract", array($realDestination, $realZipFile, $this->addSlugToPath($files), $zipLocalPath));
 		$result = $archive->extract(PCLZIP_OPT_BY_NAME, $files, 
 									PCLZIP_OPT_PATH, $realDestination, 
 									PCLZIP_OPT_REMOVE_PATH, $zipLocalPath);
@@ -1346,7 +1367,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 	
 	function copyOrMove($destDir, $selectedFiles, &$error, &$success, $move = false)
 	{
-		AJXP_Logger::debug("CopyMove", array("dest"=>$destDir, "selection" => $selectedFiles));
+		AJXP_Logger::debug("CopyMove", array("dest"=>$this->addSlugToPath($destDir), "selection" => $this->addSlugToPath($selectedFiles)));
 		$mess = ConfService::getMessages();
 		if(!$this->isWriteable($this->urlBase.$destDir))
 		{


### PR DESCRIPTION
When logging file upload, download, copy, move, delete, rename, etc., it doesn't log a reference to the repository this operation was made in. Thus, it may be hard to trace file operations using logs if you have many repositories with very similar files.

I attach a proposed patch that prepends repository slug to file path when logging it.
