### PR TITLE
WebDAV not working with USE_SESSION_CREDENTIALS

### DIFF
--- a/core/src/core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_AuthBackendBasic.php
+++ b/core/src/core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_AuthBackendBasic.php
@@ -85,7 +85,7 @@ class AJXP_Sabre_AuthBackendBasic extends Sabre\DAV\Auth\Backend\AbstractBasic{
         }
         $this->currentUser = $userpass[0];
 
-		AuthService::logUser($this->currentUser, null, true);
+		AuthService::logUser($this->currentUser, $userpass[1], true);
 		$res = $this->updateCurrentUserRights(AuthService::getLoggedUser());
 		if($res === false){
 			return false;


### PR DESCRIPTION
When trying to use a repository using session credentials, WebDAV tries to log in to repository backend with blank password.

When logging in to WebDAV, AuthService::logUser() is called with null password and $bypass_pwd = true in core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_AuthBackendBasic.php:88

``` php
AuthService::logUser($this->currentUser, null, true);
```

$pwd parameter is used in AuthService::logUser() to set credentials in core/classes/class.AuthService.php:335

``` php
if(ConfService::getCoreConf("SESSION_SET_CREDENTIALS", "auth")) {
    list($authId, $authPwd) = $authDriver->filterCredentials($user_id, $pwd);
    AJXP_Safe::storeCredentials($authId, $authPwd);
}
```

But, since $pwd parameter received is null, session password is set to an empty string, causing an error when using repositories using session credentials.
