### PR TITLE
auth.cas: Not auto creating users on first login

### DIFF
--- a/core/src/plugins/auth.cas/class.casAuthDriver.php
+++ b/core/src/plugins/auth.cas/class.casAuthDriver.php
@@ -62,10 +62,12 @@ class casAuthDriver extends serialAuthDriver
     }
     phpCAS::forceAuthentication();
     $cas_user = phpCAS::getUser();
-    
-    if($this->userExists($cas_user)){
+
+    if (!$this->userExists($cas_user) && $this->autoCreateUser())
+      $this->createUser($cas_user, openssl_random_pseudo_bytes(20));
+
+    if ($this->userExists($cas_user))
       AuthService::logUser($cas_user, "", true);
-    }
   }
 
   function getLogoutRedirect()


### PR DESCRIPTION
Auto create AjaXplorer user if CAS login was successful and plugin was configured to auto create users.
