### PR TITLE
Missing ; in plugins/conf.sql/update_3.0.3_up.sql

### DIFF
--- a/core/src/plugins/conf.sql/update_3.0.3_up.sql
+++ b/core/src/plugins/conf.sql/update_3.0.3_up.sql
@@ -1,7 +1,6 @@
-ALTER TABLE `ajxp_user_rights` CHANGE `rights` `rights` VARCHAR( 255 ) NOT NULL 
+ALTER TABLE `ajxp_user_rights` CHANGE `rights` `rights` VARCHAR( 255 ) NOT NULL;
 
 CREATE TABLE ajxp_roles (
 	role_id VARCHAR(50) PRIMARY KEY, 
 	serial_role TEXT(500) NOT NULL
 );
- 


### PR DESCRIPTION
plugins/conf.sql/update_3.0.3_up.sql misses a ; after first SQL statement.
