### PR TITLE
Recursivity bomb when copying a directory into itself

### DIFF
--- a/core/src/plugins/access.fs/class.fsAccessDriver.php
+++ b/core/src/plugins/access.fs/class.fsAccessDriver.php
@@ -1534,6 +1534,13 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
 		$mess = ConfService::getMessages();		
 		$destFile = $this->urlBase.$destDir."/".basename($srcFile);
 		$realSrcFile = $this->urlBase.$srcFile;
+
+		if (is_dir(dirname($realSrcFile)) && (strpos($destFile, rtrim($realSrcFile, "/") . "/") === 0))
+		{
+			$error[] = $mess[101];
+			return;
+		}
+
 		if(!file_exists($realSrcFile))
 		{
 			$error[] = $mess[100].$srcFile;


### PR DESCRIPTION
You have a directory called "dir1" which contains a file called "file1":

dir1/file1

AjaXplorer will let you copy dir1 into itself. When trying to accomplish this, it will create recursive copies like this:

dir1/file1
dir1/dir1/file1
dir1/dir1/dir1/file1
dir1/dir1/dir1/dir1/file1
...
