### PR TITLE
Check SSL status from PHP's HTTPS header instead of port

### DIFF
--- a/core/src/index.php
+++ b/core/src/index.php
@@ -26,7 +26,7 @@ include_once("base.conf.php");
 if( !isSet($_GET["action"]) && !isSet($_GET["get_action"])
     && !isSet($_POST["action"]) && !isSet($_POST["get_action"])
     && defined("AJXP_FORCE_SSL_REDIRECT") && AJXP_FORCE_SSL_REDIRECT === true
-    && $_SERVER['SERVER_PORT'] != 443) {
+    && $_SERVER['HTTPS'] != "on") {
     header("HTTP/1.1 301 Moved Permanently");
     header("Location: https://".$_SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']);
     exit();


### PR DESCRIPTION
I believe this is the more correct way to check if AjaXplorer is being served through SSL.

This will fix situations where..
1) the webserver serving AjaXplorer is being proxied by an SSL offloader (and the "X-Forwarded-Proto" header is set and properly interpreted)
2) the webserver serving AjaXplorer doesn't run it's SSL on the standard 443 port
