### PR TITLE
Update class.IMagickPreviewer.php

### DIFF
--- a/core/src/plugins/editor.imagick/class.IMagickPreviewer.php
+++ b/core/src/plugins/editor.imagick/class.IMagickPreviewer.php
@@ -271,8 +271,8 @@ class IMagickPreviewer extends AJXP_Plugin {
         if(!empty($customEnvPath)){
             putenv("PATH=".getenv("PATH").":".$customEnvPath);
         }
-        $params = ($this->extractAll?"-quality ".$viewerQuality:"-resize 250 ".$customOptions." -quality ".$thumbQuality);
-        $cmd = $this->getFilteredOption("IMAGE_MAGICK_CONVERT")." ".escapeshellarg(($masterFile).$pageLimit)." ".$params." ".escapeshellarg($tmpFileThumb);
+	$params = (isSet($this->pluginConf["IM_CUSTOM_OPTIONS"])?$this->pluginConf["IM_CUSTOM_OPTIONS"]." ":"")."-quality ".$this->pluginConf[($this->extractAll?"IM_VIEWER_QUALITY":"IM_THUMB_QUALITY")];
+	$cmd = $this->pluginConf["IMAGE_MAGICK_CONVERT"]." ".$params." ".escapeshellarg(($masterFile).$pageLimit)." ".escapeshellarg($tmpFileThumb);
 		AJXP_Logger::debug("IMagick Command : $cmd");
 		session_write_close(); // Be sure to give the hand back
 		exec($cmd, $out, $return);


### PR DESCRIPTION
IM_CUSTOM_OPTIONS is used even for thumbs generation, no resize for thumbs (have to be defined in quality parameter).
Parameters values examples :
- IM_CUSTOM_OPTIONS : -strip -alpha opaque
- IM_THUMB_QUALITY : 65 -density 150 -resize 250
- IM_VIEWER_QUALITY : 90 -density 300 -resize 25%
