### PR TITLE
fix set setGroupPath issue when creating a new user inside a subgroup

### DIFF
--- a/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
+++ b/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
@@ -647,7 +647,9 @@ class ajxp_confAccessDriver extends AbstractAccessDriver
                 $basePath = AuthService::getLoggedUser()->getGroupPath();
                 if(empty ($basePath)) $basePath = "/";
                 if(!empty($httpVars["group_path"])){
-                    $newUser->setGroupPath($basePath.ltrim($httpVars["group_path"], "/"));
+                    //fix problem of subgroup :"groupsubgroup1" instead of "group/subgroup1"
+                    //$newUser->setGroupPath($basePath.ltrim($httpVars["group_path"], "/"));
+                    $newUser->setGroupPath($basePath.$httpVars["group_path"]);
                 }else{
                     $newUser->setGroupPath($basePath);
                 }


### PR DESCRIPTION
There is a bug when a user with an administrator profile create another user inside a sub group.
For instance if you create a new user in a subgroup such as "group/subgroup" the groupPath is wrong is ajxp_users table : "groupsubgroup" instead of "group/subgroup".
I fix this bug editing "/var/www/ajaxplorer-core/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php" file.
Removing the "ltrim" function fixes the problem.
greetings,
ben
