### PR TITLE
Add coding standards / Add travis configuration to check it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+
+php:
+ - 5.3
+ - 5.4
+ - 5.5
+
+before_install:
+ - wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+
+script:
+ - dist/scripts/tests/syntax.sh
+ - dist/scripts/tests/codestyle.sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Please DO NOT send emails to Charles, but use the forum located on http://forum.
 
 ### How to contribute / Developer Resources
 
+#### Coding guidelines
+
+To enforce some coding standards we are using PHP-CS-Fixer
+```
+wget http://cs.sensiolabs.org/get/php-cs-fixer.phar
+php php-cs-fixer.phar fix -v --fixers=indentation,linefeed,trailing_spaces,visibility,short_tag,braces,php_closing_tag,controls_spaces,eof_ending ajaxplorer-core/
+```
+See https://github.com/fabpot/PHP-CS-Fixer#usage
+
 #### Fixing the Core
 
 If you think you have found a bug and a way to fix it neatly in the code, use a Pull Request to report this change back to us! 

--- a/dist/scripts/tests/codestyle.sh
+++ b/dist/scripts/tests/codestyle.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ -e "php-cs-fixer.phar" ]
+then
+    PHPCSFIXER=php php-cs-fixer.phar
+elif hash php-cs-fixer
+then
+    PHPCSFIXER=php-cs-fixer
+else
+    echo -e "\e[1;31mPlease install or download php-cs-fixer\e[00m";
+    echo -e "\e[1;31mhttp://cs.sensiolabs.org/\e[00m";
+    exit 1
+fi
+
+PHPCSFIXERARGS="fix -v --fixers=indentation,linefeed,trailing_spaces,visibility,short_tag,braces,php_closing_tag,controls_spaces,eof_ending"
+
+echo -e "\e[1;34mChecking Formatting/coding standards\e[00m"
+$PHPCSFIXER $PHPCSFIXERARGS --dry-run .
+rc=$?
+if [[ $rc == 0 ]]
+then
+    echo -e "\e[1;32mFormatting is OK\e[00m"
+else
+    echo -e "\e[1;31mPlease check code Formatting\e[00m"
+    echo -e "\e[1;31m$PHPCSFIXER $PHPCSFIXERARGS .\e[00m"
+    exit 1
+fi
+

--- a/dist/scripts/tests/syntax.sh
+++ b/dist/scripts/tests/syntax.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo -e "\e[1;34mChecking syntax error\e[00m"
+output=$(find . -name '*.php' -exec php --syntax-check {} \; | grep -v 'No syntax errors detected in')
+if [[ $output ]]
+then 
+    echo -e '\e[00;31mPlease check files syntax\e[00m'
+    exit 1
+else 
+    echo -e "\e[1;32mSyntax is OK\e[00m"
+fi


### PR DESCRIPTION
Hi @cdujeu,

As many part of the code aren't well formatted (tabs on one line, spaces on another, CRLF or LF depending on the file, trailing spaces, ...), i'm proposing to use coding standards for ajaxplorer.
To check/correct the conformance automatically, i'm using php-cs-fixer.
To automatically check future commit and pull request i'm suggesting https://travis-ci.org/ (ultra easy to use, and integrate nicely with github, see the red cross on my commit line)

The travis build will not pass for now, as we haven't apply the coding standards for now.

See https://github.com/fabpot/PHP-CS-Fixer#usage  for the list of available fixers.
I can add/remove fixers as you wich.

We will also be able to run unit test with travis.

To activate it (1 min), http://about.travis-ci.org/docs/user/getting-started/ (for the step 3 simply merge my PR).
