### PR TITLE
Add .gitattributes to enhance git diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.php diff=php


### PR DESCRIPTION
With this git diff show function name
instead of class name for php files

Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
