### PR TITLE
Fix dead link to the F.A.Q. about the server charset encoding check warning

### DIFF
--- a/core/src/core/tests/test.ServerEncoding.php
+++ b/core/src/core/tests/test.ServerEncoding.php
@@ -28,7 +28,7 @@ require_once('../classes/class.AbstractTest.php');
  */
 class ServerEncoding extends AbstractTest
 {
-    public function ServerEncoding() { parent::AbstractTest("Server charset encoding", "You must set a correct charset encoding in your locale definition in the form: en_us.UTF-8. Please refer to setlocale man page. If your detected locale is C, please check the <a href=\"http://www.ajaxplorer.info/wordpress/documentation-3/chapter-faq/#toc-i-have-a-warning-concerning-the-character-encoding-when-i-first-start-ajaxplorer-what-should-i-do\">F.A.Q.</a>. "); }
+    public function ServerEncoding() { parent::AbstractTest("Server charset encoding", "You must set a correct charset encoding in your locale definition in the form: en_us.UTF-8. Please refer to setlocale man page. If your detected locale is C, please check the <a href=\"http://ajaxplorer.info/knowledge-base-2/f-a-q/#39172\">F.A.Q.</a>. "); }
     public function doTest()
     {
         // Get the locale


### PR DESCRIPTION
Only a dead link replaced with the actual link to the corresponding section in the F.A.Q.
