### PR TITLE
Permit administrator to disable WebDAV on individual repositories.

### DIFF
--- a/core/src/core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_RootCollection.php
+++ b/core/src/core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_RootCollection.php
@@ -37,7 +37,7 @@ class AJXP_Sabre_RootCollection extends Sabre\DAV\SimpleCollection
             foreach ($repos as $repository) {
                 $accessType = $repository->getAccessType();
                 $driver = AJXP_PluginsService::getInstance()->getPluginByTypeName("access", $accessType);
-                if (is_a($driver, "AjxpWrapperProvider")) {
+        if (is_a($driver, "AjxpWrapperProvider") && !$repository->getOption("AJXP_WEBDAV_DISABLED")) {
                     $this->children[$repository->getSlug()] = new Sabre\DAV\SimpleCollection($repository->getSlug());
                 }
             }

--- a/core/src/plugins/core.ajaxplorer/ajxp_mixins.xml
+++ b/core/src/plugins/core.ajaxplorer/ajxp_mixins.xml
@@ -15,6 +15,7 @@
             <param group="MIXIN_MESSAGE[Repository Commons]" name="DEFAULT_RIGHTS" type="select" choices="r|Read Only,rw|Read and Write,w|Write Only (upload)" label="MIXIN_MESSAGE[Default Rights]" description="MIXIN_MESSAGE[This right pattern (empty, r, or rw) will be applied at user creation for this repository.]" default=""/>
             <param group="MIXIN_MESSAGE[Repository Commons]" name="AJXP_SLUG" type="string" label="MIXIN_MESSAGE[Alias]" description="MIXIN_MESSAGE[Alias for replacing the generated unique id of the repository]" mandatory="false" no_templates="true"/>
             <param group="MIXIN_MESSAGE[Repository Commons]" name="AJXP_GROUP_PATH_PARAMETER" type="string" label="MIXIN_MESSAGE[Group Path]" description="MIXIN_MESSAGE[Set this repository group owner : only users of this group will see it]" mandatory="false" no_templates="true"/>
+	    <param group="MIXIN_MESSAGE[Repository Commons]" name="AJXP_WEBDAV_DISABLED" type="boolean" label="MIXIN_MESSAGE[Disable WebDAV]" description="MIXIN_MESSAGE[Explicitly disable WebDAV access for this repository.]" mandatory="false" default="false" no_templates="true"/>
 		</server_settings>
 	</slug_provider>
 	<template_provider>

--- a/core/src/plugins/core.conf/class.AbstractConfDriver.php
+++ b/core/src/plugins/core.conf/class.AbstractConfDriver.php
@@ -632,7 +632,7 @@ abstract class AbstractConfDriver extends AJXP_Plugin
                 foreach ($repoList as $repoIndex => $repoObject) {
                     $accessType = $repoObject->getAccessType();
                     $driver = AJXP_PluginsService::getInstance()->getPluginByTypeName("access", $accessType);
-                    if (is_a($driver, "AjxpWrapperProvider") && ($loggedUser->canRead($repoIndex) || $loggedUser->canWrite($repoIndex))) {
+            if (is_a($driver, "AjxpWrapperProvider") && !$repoObject->getOption("AJXP_WEBDAV_DISABLED") && ($loggedUser->canRead($repoIndex) || $loggedUser->canWrite($repoIndex))) {
                         $davRepos[$repoIndex] = $webdavBaseUrl ."".($repoObject->getSlug()==null?$repoObject->getId():$repoObject->getSlug());
                     }
                 }


### PR DESCRIPTION
This is necessary for repositories that depend on session credentials
because clients such as Windows default WebDAV do not use sessions.
