### PR TITLE
Update class.FilesystemMounter.php

### DIFF
--- a/core/src/plugins/meta.mount/class.FilesystemMounter.php
+++ b/core/src/plugins/meta.mount/class.FilesystemMounter.php
@@ -121,7 +121,7 @@ class FilesystemMounter extends AJXP_Plugin
         $UNC_PATH = $this->getOption("UNC_PATH", $user, $password);
         $MOUNT_OPTIONS = $this->getOption("MOUNT_OPTIONS", $user, $password);
 
-        $cmd = ($MOUNT_SUDO?"sudo":"")." mount -t ".$MOUNT_TYPE." ".$UNC_PATH." ".$MOUNT_POINT." -o ".$MOUNT_OPTIONS;
+        $cmd = ($MOUNT_SUDO? "sudo ": ""). "mount -t " .$MOUNT_TYPE. (empty( $MOUNT_OPTIONS )? " " : " -o " .$MOUNT_OPTIONS. " " ) .$UNC_PATH. " " .$MOUNT_POINT;
         shell_exec($cmd);
         // Check it is correctly mounted now!
         $cmd = ($MOUNT_SUDO?"sudo":"")." mount | grep ".escapeshellarg($MOUNT_POINT);


### PR DESCRIPTION
Fixed the $cmd to have the mount options before the paths to work with MAC OS X server mount command. Also made the parameter not added when there are no options to pass.
