### PR TITLE
Add YOURLS shortener, with optional IDN support

### DIFF
--- a/core/src/plugins/shorten.multi/class.multiShortener.php
+++ b/core/src/plugins/shorten.multi/class.multiShortener.php
@@ -114,6 +114,41 @@ class multiShortener extends AJXP_Plugin
                 }
                 break;
 
+            case 4:
+                $url = $params["ob_output"];
+                if (!isSet($type["YOURLS_DOMAIN"])) {
+                    print($url);
+                    $this->logError("Config", "yourls Shortener : you must set the domain name");
+                    return;
+                }
+                if (!isSet($type["YOURLS_APIKEY"])) {
+                    print($url);
+                    $this->logError("Config", "yourls Shortener : you must set the api key");
+                    return;
+                }
+                $useidn = false;
+                if (isSet($type["YOURLS_USEIDN"])) {
+                    $useidn = $type["YOURLS_USEIDN"];
+                }
+                $yourls_domain = $type["YOURLS_DOMAIN"];
+                $yourls_api = $type["YOURLS_APIKEY"];
+                $yourls = 'http://'.$yourls_domain.'/yourls-api.php?signature='.$yourls_api.'&action=shorturl&format=simple&url='.urlencode($url);
+                $response = AJXP_Utils::getRemoteContent($yourls);
+                if (isSet($response)) {
+                    $shorturl = $response;
+                    if ($useidn) {
+                        // WARNING: idn_to_utf8 requires php-idn module.
+                        // WARNING: http_build_url requires php-pecl-http module.
+                        $purl = parse_url($shorturl);
+                        $purl['host'] = idn_to_utf8($purl['host']);
+                        $shorturl = http_build_url($purl);
+                    }
+                    print($shorturl);
+                    $this->updateMetaShort($httpVars["file"], $shorturl);
+                } else {
+                    print($url);
+                }
+                break;
         }
 
 

--- a/core/src/plugins/shorten.multi/i18n/conf/en.php
+++ b/core/src/plugins/shorten.multi/i18n/conf/en.php
@@ -22,4 +22,6 @@ $mess=array(
 "Bit.ly account user name" => "Bit.ly account user name",
 "API Key" => "API Key",
 "Bit.ly account API Key" => "Bit.ly account API Key",
+"Yourls domain" => "Yourls domain",
+"Use IDN" => "Use IDN",
 );

--- a/core/src/plugins/shorten.multi/i18n/conf/es.php
+++ b/core/src/plugins/shorten.multi/i18n/conf/es.php
@@ -22,4 +22,6 @@ $mess=array(
 "Bit.ly account user name" => "Usuario de la cuenta Bit.ly",
 "API Key" => "Clave API",
 "Bit.ly account API Key" => "Clave API de la cuenta Bit.ly",
+"Yourls domain" => "Yourls domain",
+"Use IDN" => "Use IDN",
 );

--- a/core/src/plugins/shorten.multi/i18n/conf/fr.php
+++ b/core/src/plugins/shorten.multi/i18n/conf/fr.php
@@ -22,4 +22,6 @@ $mess=array(
 "Bit.ly account user name" => "Bit.ly account user name",
 "API Key" => "API Key",
 "Bit.ly account API Key" => "Bit.ly account API Key",
+"Yourls domain" => "Yourls domain",
+"Use IDN" => "Use IDN",
 );

--- a/core/src/plugins/shorten.multi/i18n/conf/pt.php
+++ b/core/src/plugins/shorten.multi/i18n/conf/pt.php
@@ -24,4 +24,6 @@ $mess=array(
 "Bit.ly account API Key" => "Chave API da conta Bit.ly",
 "Shorten Download Links before sending them back to the user." => "Shorten Download Links before sending them back to the user.",
 "Shorten Download Links before sending them back to the user. Requires a Bit.ly account." => "Shorten Download Links before sending them back to the user. Requires a Bit.ly account.",
+"Yourls domain" => "Yourls domain",
+"Use IDN" => "Use IDN",
 );

--- a/core/src/plugins/shorten.multi/manifest.xml
+++ b/core/src/plugins/shorten.multi/manifest.xml
@@ -23,6 +23,10 @@
         <global_param group_switch_name="shorten_type" group_switch_label="goo.gl" group_switch_value="goo.gl" name="GOOGL_APIKEY" type="string" label="CONF_MESSAGE[API Key]" description="CONF_MESSAGE[API Key]" mandatory="false"/>
         <global_param group_switch_name="shorten_type" group_switch_label="po.st" group_switch_value="po.st" name="shorten_type" type="hidden" label="" description="" mandatory="false" default="3"/>
         <global_param group_switch_name="shorten_type" group_switch_label="po.st" group_switch_value="po.st" name="POST_APIKEY" type="string" label="CONF_MESSAGE[API Key]" description="CONF_MESSAGE[API Key]" mandatory="false"/>
+		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="shorten_type" type="hidden" label="" description="" mandatory="false" default="4"/>
+		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="YOURLS_DOMAIN" type="string" label="CONF_MESSAGE[Short domain]" description="CONF_MESSAGE[Yourls domain]" mandatory="false"/>
+		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="YOURLS_APIKEY" type="string" label="CONF_MESSAGE[API Key]" description="CONF_MESSAGE[API Key]" mandatory="false"/>
+		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="YOURLS_USEIDN" type="boolean" label="CONF_MESSAGE[Use IDN]" description="CONF_MESSAGE[Use IDN]" mandatory="false" default="false"/>
     </server_settings>
 	<registry_contributions>
         <actions>


### PR DESCRIPTION
Add YOURLS support, the open source url shortener (http://yourls.org)
As YOURLS is self hosted, optional IDN conversion to display short utf8 url instead of punycode ascii url for those who use international domain names.
