### PR TITLE
Add new Avatar plugin category (with Gravatar and Libravatar)

### DIFF
--- a/core/src/plugins/avatar.gravatar/class.Gravatar.php
+++ b/core/src/plugins/avatar.gravatar/class.Gravatar.php
@@ -1,0 +1,42 @@
+<?php
+/*
+* Gravatar plugin for AjaXplorer
+*/
+
+defined('AJXP_EXEC') or die( 'Access not allowed');
+
+/**
+ * Simple implementation of Gravatar
+ * @package AjaXplorer_Plugins
+ * @subpackage Avatar
+ */
+class Gravatar extends AJXP_Plugin
+{
+    public function receiveAction($action, $httpVars, $filesVars)
+    {
+        $type = $this->getFilteredOption("GRAVATAR_TYPE");
+        if ($action == "get_avatar") {
+            $url = "";
+            if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+                $url = "https://secure.gravatar.com";
+            } else {
+                $url = "http://www.gravatar.com";
+            }
+            $url .= "/avatar/";
+            if (isSet($httpVars["userid"])) {
+                $userid = $httpVars["userid"];
+                if (AuthService::usersEnabled() && AuthService::userExists($userid)) {
+                    $confDriver = ConfService::getConfStorageImpl();
+                    $user = $confDriver->createUserObject($userid);
+                    $userEmail = $user->personalRole->filterParameterValue("core.conf", "email", AJXP_REPO_SCOPE_ALL, "");
+                    if (!empty($userEmail)) {
+                        $url .= md5(strtolower(trim($userEmail)));
+                    }
+                }
+            }
+            $url .= "?s=80&r=g";
+            $url .= "&d=" . $type;
+            print($url);
+        }
+    }
+}

--- a/core/src/plugins/avatar.gravatar/i18n/conf/en.php
+++ b/core/src/plugins/avatar.gravatar/i18n/conf/en.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Gravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Gravatar" => "Gravatar",
+"Get user avatar from Gravatar." => "Get user avatar from Gravatar.",
+"Gravatar type" => "Gravatar type",
+);

--- a/core/src/plugins/avatar.gravatar/i18n/conf/es.php
+++ b/core/src/plugins/avatar.gravatar/i18n/conf/es.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Gravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Gravatar" => "Gravatar",
+"Get user avatar from Gravatar." => "Get user avatar from Gravatar.",
+"Gravatar type" => "Gravatar type",
+);

--- a/core/src/plugins/avatar.gravatar/i18n/conf/fr.php
+++ b/core/src/plugins/avatar.gravatar/i18n/conf/fr.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Gravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Gravatar" => "Gravatar",
+"Get user avatar from Gravatar." => "Get user avatar from Gravatar.",
+"Gravatar type" => "Gravatar type",
+);

--- a/core/src/plugins/avatar.gravatar/i18n/conf/pt.php
+++ b/core/src/plugins/avatar.gravatar/i18n/conf/pt.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Gravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Gravatar" => "Gravatar",
+"Get user avatar from Gravatar." => "Get user avatar from Gravatar.",
+"Gravatar type" => "Gravatar type",
+);

--- a/core/src/plugins/avatar.gravatar/manifest.xml
+++ b/core/src/plugins/avatar.gravatar/manifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ajxp_plugin id="avatar.gravatar" enabled="false" label="CONF_MESSAGE[Gravatar]" description="CONF_MESSAGE[Get user avatar from Gravatar.]"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="file:../core.ajaxplorer/ajxp_registry.xsd">
+    <plugin_info>
+        <plugin_author>Afterster</plugin_author>
+        <core_relation packaged="true" tested_version="5.0"/>
+    </plugin_info>
+    <client_settings>
+        <resources>
+            <i18n namespace="avatar_gravatar" path="plugins/avatar.gravatar/i18n" />
+        </resources>
+    </client_settings>
+    <server_settings>
+        <global_param name="GRAVATAR_TYPE" type="select" choices="blank|Blank,identicon|IdentIcon,mm|Mystery-Man,monsterid|MonsterID,retro|Retro,wavatar|Wavatar" label="CONF_MESSAGE[Gravatar type]" description="CONF_MESSAGE[Gravatar type]" mandatory="true" default="identicon"/>
+    </server_settings>
+    <registry_contributions>
+        <actions>
+            <action name="get_avatar">
+                <processing>
+                    <serverCallback methodName="receiveAction"></serverCallback>
+                </processing>
+            </action>
+        </actions>
+    </registry_contributions>
+    <class_definition filename="plugins/avatar.gravatar/class.Gravatar.php" classname="Gravatar"/>
+</ajxp_plugin>

--- a/core/src/plugins/avatar.gravatar/plugin_doc.html
+++ b/core/src/plugins/avatar.gravatar/plugin_doc.html
@@ -1,0 +1,1 @@
+<p>Get user avatar from Gravatar, based on email address.</p>

--- a/core/src/plugins/avatar.libravatar/class.Libravatar.php
+++ b/core/src/plugins/avatar.libravatar/class.Libravatar.php
@@ -1,0 +1,43 @@
+<?php
+/*
+* Libravatar plugin for AjaXplorer
+*/
+
+defined('AJXP_EXEC') or die( 'Access not allowed');
+
+/**
+ * Simple implementation of Libravatar
+ * @package AjaXplorer_Plugins
+ * @subpackage Avatar
+ */
+class Libravatar extends AJXP_Plugin
+{
+    public function receiveAction($action, $httpVars, $filesVars)
+    {
+        $type = $this->getFilteredOption("LIBRAVATAR_TYPE");
+        if ($action == "get_avatar") {
+            $url = "";
+            // Federated Servers are not supported here without libravatar.org. Should query DNS server first.
+            if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+                $url = "https://seccdn.libravatar.org";
+            } else {
+                $url = "http://cdn.libravatar.org";
+            }
+            $url .= "/avatar/";
+            if (isSet($httpVars["userid"])) {
+                $userid = $httpVars["userid"];
+                if (AuthService::usersEnabled() && AuthService::userExists($userid)) {
+                    $confDriver = ConfService::getConfStorageImpl();
+                    $user = $confDriver->createUserObject($userid);
+                    $userEmail = $user->personalRole->filterParameterValue("core.conf", "email", AJXP_REPO_SCOPE_ALL, "");
+                    if (!empty($userEmail)) {
+                        $url .= md5(strtolower(trim($userEmail)));
+                    }
+                }
+            }
+            $url .= "?s=80";
+            $url .= "&d=" . $type;
+            print($url);
+        }
+    }
+}

--- a/core/src/plugins/avatar.libravatar/i18n/conf/en.php
+++ b/core/src/plugins/avatar.libravatar/i18n/conf/en.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Libravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Libravatar" => "Libravatar",
+"Get user avatar from Libravatar." => "Get user avatar from Libravatar.",
+"Libravatar type" => "Libravatar type",
+);

--- a/core/src/plugins/avatar.libravatar/i18n/conf/es.php
+++ b/core/src/plugins/avatar.libravatar/i18n/conf/es.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Libravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Libravatar" => "Libravatar",
+"Get user avatar from Libravatar." => "Get user avatar from Libravatar.",
+"Libravatar type" => "Libravatar type",
+);

--- a/core/src/plugins/avatar.libravatar/i18n/conf/fr.php
+++ b/core/src/plugins/avatar.libravatar/i18n/conf/fr.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Libravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Libravatar" => "Libravatar",
+"Get user avatar from Libravatar." => "Get user avatar from Libravatar.",
+"Libravatar type" => "Libravatar type",
+);

--- a/core/src/plugins/avatar.libravatar/i18n/conf/pt.php
+++ b/core/src/plugins/avatar.libravatar/i18n/conf/pt.php
@@ -1,0 +1,9 @@
+<?php
+/*
+* Libravatar plugin for AjaXplorer
+*/
+$mess=array(
+"Libravatar" => "Libravatar",
+"Get user avatar from Libravatar." => "Get user avatar from Libravatar.",
+"Libravatar type" => "Libravatar type",
+);

--- a/core/src/plugins/avatar.libravatar/manifest.xml
+++ b/core/src/plugins/avatar.libravatar/manifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ajxp_plugin id="avatar.libravatar" enabled="false" label="CONF_MESSAGE[Libravatar]" description="CONF_MESSAGE[Get user avatar from Libravatar.]"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="file:../core.ajaxplorer/ajxp_registry.xsd">
+    <plugin_info>
+        <plugin_author>Afterster</plugin_author>
+        <core_relation packaged="true" tested_version="5.0"/>
+    </plugin_info>
+    <client_settings>
+        <resources>
+            <i18n namespace="avatar_libravatar" path="plugins/avatar.libravatar/i18n" />
+        </resources>
+    </client_settings>
+    <server_settings>
+        <global_param name="LIBRAVATAR_TYPE" type="select" choices="identicon|IdentIcon,mm|Mystery-Man,monsterid|MonsterID,retro|Retro,wavatar|Wavatar" label="CONF_MESSAGE[Libravatar type]" description="CONF_MESSAGE[Libravatar type]" mandatory="true" default="identicon"/>
+    </server_settings>
+    <registry_contributions>
+        <actions>
+            <action name="get_avatar">
+                <processing>
+                    <serverCallback methodName="receiveAction"></serverCallback>
+                </processing>
+            </action>
+        </actions>
+    </registry_contributions>
+    <class_definition filename="plugins/avatar.libravatar/class.Libravatar.php" classname="Libravatar"/>
+</ajxp_plugin>

--- a/core/src/plugins/avatar.libravatar/plugin_doc.html
+++ b/core/src/plugins/avatar.libravatar/plugin_doc.html
@@ -1,0 +1,1 @@
+<p>Get user avatar from Libravatar, based on email address.</p>

--- a/core/src/plugins/gui.ajax/res/js/ajaxplorer/class.UserWidget.js
+++ b/core/src/plugins/gui.ajax/res/js/ajaxplorer/class.UserWidget.js
@@ -68,9 +68,21 @@ Class.create("UserWidget", {
                 var label = '<ajxp:message ajxp_message_id="142">'+MessageHash[142]+'</ajxp:message><i ajxp_message_title_id="189" title="'+MessageHash[189]+'">'+ oUser.id +' </i>';
                 if(oUser.getPreference('USER_DISPLAY_NAME')){
                     var img = '';
+					var imgSrc = '';
+					var conn = new Connexion();
                     if(oUser.getPreference("avatar")){
-                        var conn = new Connexion();
-                        var imgSrc = conn._baseUrl + "&get_action=get_binary_param&binary_id=" + oUser.getPreference("avatar") + "&user_id=" + oUser.id;
+                        imgSrc = conn._baseUrl + "&get_action=get_binary_param&binary_id=" + oUser.getPreference("avatar") + "&user_id=" + oUser.id;
+                    } else {
+                        // Get avatar from avatar plugins
+						conn.addParameter('get_action', 'get_avatar');
+						conn.addParameter('userid', oUser.id);
+						conn.onComplete = function(transport){
+							imgSrc = transport.responseText;
+						}
+						conn.sendSync();
+                    }
+
+                    if (imgSrc != '') {
                         img = '<img src="'+imgSrc+'" alt="avatar" class="user_widget_mini">';
                     }
                     label = '<i ajxp_message_title_id="189" title="'+MessageHash[189]+'">' + img + oUser.getPreference('USER_DISPLAY_NAME') + '</i>';


### PR DESCRIPTION
This merge request following my ticket #333. It adds a new Avatar plugin category and two new plugins:
- avatar.gravatar: Get user avatar from Gravatar
- avatar.libravatar: Get user avatar from Libravatar

Avatar plugins are only called if the user doesn't have uploaded its own avatar (which is convenient in code and is also the more logical thing to do I think).
