### PR TITLE
ajxp_users.login must be in GROUP BY clause

### DIFF
--- a/core/src/plugins/conf.sql/class.sqlConfDriver.php
+++ b/core/src/plugins/conf.sql/class.sqlConfDriver.php
@@ -381,7 +381,7 @@ class sqlConfDriver extends AbstractConfDriver
     {
         $result = array();
         // OLD METHOD
-        $children_results = dibi::query('SELECT [ajxp_users].[login] FROM [ajxp_user_rights],[ajxp_users] WHERE [repo_uuid] = %s AND [ajxp_user_rights].[login] = [ajxp_users].[login] GROUP BY [ajxp_user_rights].[login]', $repositoryId);
+        $children_results = dibi::query('SELECT [ajxp_users].[login] FROM [ajxp_user_rights],[ajxp_users] WHERE [repo_uuid] = %s AND [ajxp_user_rights].[login] = [ajxp_users].[login] GROUP BY [ajxp_users].[login]', $repositoryId);
         $all = $children_results->fetchAll();
         foreach ($all as $item) {
             $result[$item["login"]] = $this->createUserObject($item["login"]);


### PR DESCRIPTION
(Correct PostgreSQL error)

ERREUR:  la colonne « ajxp_users.login » doit apparaître dans la clause GROUP BY ou doit être utilisé dans une fonction d'agrégat
