### PR TITLE
Fixes Samba access plugin hanging frequently 

### DIFF
--- a/core/src/plugins/access.smb/smb.php
+++ b/core/src/plugins/access.smb/smb.php
@@ -185,6 +185,7 @@ class smb
             $env = array("LC_ALL" => AJXP_LOCALE);
         }
         $process = proc_open($cmd, $descriptorspec, $pipes, null, $env);
+		stream_set_blocking($pipes[2], 0);
         if (is_resource($process)) {
             fclose($pipes[0]);
             $error = stream_get_contents($pipes[2]);


### PR DESCRIPTION
Fixes Samba hanging frequently by applying the instructions available at http://www.php.net/manual/en/function.proc-open.php#81317.
