### PR TITLE
preg_replace(): The /e modifier is deprecated in PHP5.5

### DIFF
--- a/core/src/plugins/core.mq/vendor/phpws/websocket.functions.php
+++ b/core/src/plugins/core.mq/vendor/phpws/websocket.functions.php
@@ -100,7 +100,7 @@ class WebSocketFunctions {
         $fields = explode("\r\n", preg_replace('/\x0D\x0A[\x09\x20]+/', ' ', $header));
         foreach ($fields as $field) {
             if (preg_match('/([^:]+): (.+)/m', $field, $match)) {
-                $match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+                $match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./', function($matches){return strtoupper($matches[0]);}, strtolower(trim($match[1])));
                 if (isset($retVal[$match[1]])) {
                     $retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
                 } else {


### PR DESCRIPTION
should fix #312

not tested (i'm not using websockets right now)

Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
