### PR TITLE
Update Sendfile Code for NGINX

### DIFF
--- a/core/src/plugins/access.fs/class.fsAccessDriver.php
+++ b/core/src/plugins/access.fs/class.fsAccessDriver.php
@@ -1339,21 +1339,19 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                 header('Content-Disposition: attachment; filename="' . basename($filePathOrData) . '"');
                 return;
             }
-    if ($this->getFilteredOption("USE_XACCELREDIRECT", $this->repository->getId()) && $this->wrapperClassName == "fsAccessWrapper" && array_key_exists("X-Accel-Mapping",$_SERVER)) {
-        if(!$realfileSystem) $filePathOrData = fsAccessWrapper::getRealFSReference($filePathOrData);
-        $filePathOrData = str_replace("\\", "/", $filePathOrData);
-        $filePathOrData = SystemTextEncoding::toUTF8($filePathOrData);
-        $mapping = explode('=',$_SERVER['X-Accel-Mapping']);
-        $replacecount = 0;
-        $accelfile = str_replace($mapping[0],$mapping[1],$filePathOrData,$replacecount);
-        if ($replacecount == 1) {
-            header("X-Accel-Redirect: $accelfile");
-            header("Content-type: application/octet-stream");
-            header('Content-Disposition: attachment; filename="' . basename($accelfile) . '"');
-            return;
+    if ($this->getFilteredOption("USE_XACCELREDIRECT", $this->repository->getId()) && $this->wrapperClassName == "fsAccessWrapper") {
+        $uid = $this->repository->getId();
+        if ($uid === 0) {
+            $filepath = "files".substr($filePathOrData,11);
+        } elseif ($uid === 1) {
+            $loggedUser = AuthService::getLoggedUser();
+            $filepath = "personal/".$loggedUser->getId().substr($filePathOrData,11);
         } else {
-            $this->logError("X-Accel-Redirect","Problem with X-Accel-Mapping for file $filePathOrData");
+            $filepath = $this->repository->getDisplay().substr($filePathOrData,42);
         }
+        $accelfile = dirname($_SERVER["REQUEST_URI"])."/data/".$filepath;
+        header("X-Accel-Redirect: $accelfile");
+        return;
     }
             $stream = fopen("php://output", "a");
             if ($realfileSystem) {

--- a/core/src/plugins/access.fs/class.fsAccessDriver.php
+++ b/core/src/plugins/access.fs/class.fsAccessDriver.php
@@ -1349,7 +1349,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
         } else {
             $filepath = $this->repository->getDisplay().substr($filePathOrData,42);
         }
-        $accelfile = dirname($_SERVER["REQUEST_URI"])."/data/".$filepath;
+        $accelfile = dirname($_SERVER["REQUEST_URI"])."/xaccel/".$filepath;
         header("X-Accel-Redirect: $accelfile");
         return;
     }


### PR DESCRIPTION
This will send **/WEBROOT**/xaccel/**FILEPATH** to NGINX, **FILEPATH** can be..
1. files/RELATIVE-PATH = "Common Files"
2. personal/**USER**/RELATIVE-PATH = "My Files"
3. **WORKSPACE**/RELATIVE-PATH = "Additional FS Workspaces"
## NGINX Config Changes 

```
location ^~ /xaccel {
    internal;
    alias /path/to/pydio/data;

#    location /data/ADDITIONAL-FS-WORKSPACE-NAME {
#        alias /path/to/additional-fs-workspace;
#    }

}
```

**fastcgi_param X-Accel-Mapping** is no longer needed and can be removed.

---

This respects non-default webroots (e.g. http://example.com/pydio) avoiding location conflicts in NGINX config files.  It also works for multiple workspaces unlike the previous method.  Fixes https://github.com/pydio/pydio-core/issues/501
