### PR TITLE
Define Full name with accent is not possible from users settings if Windows OS

### DIFF
--- a/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
+++ b/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
@@ -126,7 +126,7 @@ class ajxp_confAccessDriver extends AbstractAccessDriver
                 break;
             case "parameters_to_form_definitions" :
 
-                $data = json_decode(AJXP_Utils::decodeSecureMagic($httpVars["json_parameters"]), true);
+                $data = json_decode($httpVars["json_parameters"], true);
                 AJXP_XMLWriter::header("standard_form");
                 foreach ($data as $repoScope => $pluginsData) {
                     echo("<repoScope id='$repoScope'>");
@@ -587,8 +587,7 @@ class ajxp_confAccessDriver extends AbstractAccessDriver
                     throw new Exception("Cant find role! ");
                 }
 
-                $jsonData = AJXP_Utils::decodeSecureMagic($httpVars["json_data"]);
-                $data = json_decode($jsonData, true);
+                $data = json_decode($httpVars["json_data"], true);
                 $roleData = $data["ROLE"];
                 $forms = $data["FORMS"];
                 $binariesContext = array();


### PR DESCRIPTION
if I understood everything, there is a conflict between json_decode and AJXP_Utils::decodeSecureMagic

decodeSecureMagic = decode from UTF8 to local encoding ;-)
json_decode works only with UTF-8
#456
