### PR TITLE
Add options for separate client/server websocket settings

### DIFF
--- a/core/src/plugins/core.mq/class.MqManager.php
+++ b/core/src/plugins/core.mq/class.MqManager.php
@@ -268,7 +268,7 @@ class MqManager extends AJXP_Plugin
             }
         }
 
-        $cmd = ConfService::getCoreConf("CLI_PHP")." ws-server.php -host=".$params["WS_SERVER_HOST"]." -port=".$params["WS_SERVER_PORT"]." -path=".$params["WS_SERVER_PATH"];
+        $cmd = ConfService::getCoreConf("CLI_PHP")." ws-server.php -host=".$params["WS_SERVER_BIND_HOST"]." -port=".$params["WS_SERVER_BIND_PORT"]." -path=".$params["WS_SERVER_PATH"];
         chdir(AJXP_INSTALL_PATH.DIRECTORY_SEPARATOR.AJXP_PLUGINS_FOLDER.DIRECTORY_SEPARATOR."core.mq");
         $process = AJXP_Controller::runCommandInBackground($cmd, null);
         if ($process != null) {

--- a/core/src/plugins/core.mq/manifest.xml
+++ b/core/src/plugins/core.mq/manifest.xml
@@ -11,8 +11,10 @@
         <global_param group="CONF_MESSAGE[Inner Messaging]" description="CONF_MESSAGE[Post the notification in a temporary queue. You must set up the scheduler accordingly to make sure the queue is then consumed on a regularly basis.]" label="CONF_MESSAGE[Queue notifications]" name="USE_QUEUE" type="boolean" default="false"/>
 
         <global_param group="WebSocket Server" description="WebSocket server is running" label="WebSocket" name="WS_SERVER_ACTIVE" type="boolean" expose="true"/>
-        <global_param group="WebSocket Server" description="WebSocket server host" label="WS Host" name="WS_SERVER_HOST" type="string" expose="true"/>
-        <global_param group="WebSocket Server" description="WebSocket server port" label="WS Port" name="WS_SERVER_PORT" type="string" expose="true" default="8090"/>
+        <global_param group="WebSocket Server" description="WebSocket client connect address" label="WS Client Address" name="WS_SERVER_HOST" type="string" expose="true"/>
+        <global_param group="WebSocket Server" description="WebSocket client connect port" label="WS Client Port" name="WS_SERVER_PORT" type="string" expose="true" default="8090"/>
+        <global_param group="WebSocket Server" description="WebSocket server bind address" label="WS Server Host" name="WS_SERVER_BIND_HOST" type="string" expose="true"/>
+        <global_param group="WebSocket Server" description="WebSocket server bind port" label="WS Server Port" name="WS_SERVER_BIND_PORT" type="string" expose="true" default="8090"/>
         <global_param group="WebSocket Server" description="WebSocket handler path" label="WS Path" name="WS_SERVER_PATH" type="string" expose="true"/>
         <global_param group="WebSocket Server" description="WebSocket admin key" label="WS Key" name="WS_SERVER_ADMIN" type="string"/>
         <global_param group="WebSocket Server" type="monitor" name="WS_STATUS" choices="run_plugin_action:core.mq:getWebSocketStatus" label="CONF_MESSAGE[WebSocket Server Status]" description="CONF_MESSAGE[Try to detect if the server is running correctly]" mandatory="false"/>


### PR DESCRIPTION
I'm running Pydio in a container, it's not able to see/access the host machine's IP address.

If I set the IP to the container's IP, the websocket server can start, but the client can't connect.

If I set the IP to the host machine's IP, the websocket server can't start (since it's unable to bind to that address).

This separates the server and client parameters. I believe this will allow admins to setup proxying as well.
