### PR TITLE
SSL detection correction

### DIFF
--- a/core/src/core/classes/class.AJXP_Utils.php
+++ b/core/src/core/classes/class.AJXP_Utils.php
@@ -852,7 +852,7 @@ class AJXP_Utils
         if (php_sapi_name() == "cli") {
             AJXP_Logger::debug("WARNING, THE SERVER_URL IS NOT SET, WE CANNOT BUILD THE MAIL ADRESS WHEN WORKING IN CLI");
         }
-        $protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http');
+        $protocol = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http');
         $port = (($protocol === 'http' && $_SERVER['SERVER_PORT'] == 80 || $protocol === 'https' && $_SERVER['SERVER_PORT'] == 443)
                 ? "" : ":" . $_SERVER['SERVER_PORT']);
         $name = $_SERVER["SERVER_NAME"];


### PR DESCRIPTION
$protocol always equals 'https' because $_SERVER['HTTPS'] !== 'off' always evaluates to true which causes the shared links to always use https even if the server doesn't use ssl.

This line was tested on two different servers running php5-fpm 5.3.10 with nginx on ubuntu 12.04, one configured with ssl and the other without ssl.
With the original test, $protocol always equals 'https', with the modification it correctly equals 'https' on the server with ssl and 'http' on the other server.
