### PR TITLE
Folder "Recycle_bin" must be Hidden with attribute "H" if Windows OS

### DIFF
--- a/core/src/plugins/access.fs/class.fsAccessDriver.php
+++ b/core/src/plugins/access.fs/class.fsAccessDriver.php
@@ -71,6 +71,8 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                 @mkdir($path."/".$recycle);
                 if (!is_dir($path."/".$recycle)) {
                     throw new AJXP_Exception("Cannot create recycle bin folder. Please check repository configuration or that your folder is writeable!");
+                } elseif (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+                    $attributes = shell_exec('attrib +H ' . $path . "/" . $recycle);
                 }
             }
             $dataTemplate = $this->repository->getOption("DATA_TEMPLATE");


### PR DESCRIPTION
Useful if the Repo is accessed directly from "explorer" Windows for others user who don't use Pydio.
In this case the folder "Recycle_bin" must be Hidden.
