### PR TITLE
Do not show password prompt when enabling WebDAV if using basic auth.

### DIFF
--- a/core/src/plugins/access.ajxp_user/class.WebDAVprefsEditor.js
+++ b/core/src/plugins/access.ajxp_user/class.WebDAVprefsEditor.js
@@ -73,12 +73,14 @@ Class.create("WebDAVprefsEditor", AjxpPane, {
                         ajaxplorer.webdavCurrentPreferences = transport.responseJSON;
                         if(ajaxplorer.webdavCurrentPreferences.webdav_active){
                             if(!ajaxplorer.webdavCurrentPreferences.digest_set
-                                || ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
+                                && !ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
                                 element.down('#webdav_password_form').show();
                             }
                             ajaxplorer.displayMessage("SUCCESS", MessageHash[408]);
                         }else {
-                            element.down('#webdav_password_form').hide();
+                            if(!ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
+                                element.down('#webdav_password_form').hide();
+                            }
                             ajaxplorer.displayMessage("SUCCESS", MessageHash[409]);
                         }
                     };


### PR DESCRIPTION
Correct the check for basic authentication to prevent prompting the user to create a password when enabling WebDAV. Also, do not try to hide the prompt because it's not shown when using basic authentication. This was preventing the success message from showing.
