### PR TITLE
access.ftp fails to check if files are writable

### DIFF
--- a/core/src/plugins/access.ftp/class.ftpAccessDriver.php
+++ b/core/src/plugins/access.ftp/class.ftpAccessDriver.php
@@ -214,6 +214,20 @@ class ftpAccessDriver extends fsAccessDriver
 
     }
 
+    // Checks if a file belongs to currently logged in FTP user
+    private function isFileOwner($path)
+    {
+        $ftp = new ftpAccessWrapper();
+        $stat = $ftp->url_stat($path, 2);
+        $urlParts = AJXP_Utils::safeParseUrl($path);
+        $repository = ConfService::getRepositoryById($urlParts["host"]);
+        $credentials = AJXP_Safe::tryLoadingCredentialsFromSources($urlParts, $repository);
+        if (empty($credentials["user"]))
+            return is_writable($path);
+        if ((string)$stat["uid"] == $credentials["user"])
+            return true;
+    }
+
     public function isWriteable($path, $type="dir")
     {
         $parts = parse_url($path);
@@ -221,9 +235,15 @@ class ftpAccessDriver extends fsAccessDriver
         if ($type == "dir" && ($dir == "" || $dir == "/" || $dir == "\\")) { // ROOT, WE ARE NOT SURE TO BE ABLE TO READ THE PARENT
             return true;
         } else {
-            return is_writable($path);
+            $perms = substr(decoct(fileperms($path)), -3);
+            // World writable files
+            if (preg_match("/..[2367]$/", $perms))
+                return true;
+            // Files belonging to currently logged in FTP user that are writable by owner
+            if ((preg_match("/^[2367]/", $perms)) && ($this->isFileOwner($path)))
+                return true;
         }
-
+        return false;
     }
 
     public function deldir($location)


### PR DESCRIPTION
I've found that, to check if a repository file is writable, access.ftp seems to check if web server user can write to that file. But this check is wrong for FTP repositories, it should check if FTP user can write to that file, not web server user.
Thus, delete/rename/etc. buttons are only enabled when files are owned by web server user (www-data or whatever) and not when they belong to FTP user currently logged in.
May it be related to issue #429? I already tried the patch there with no success.