### PR TITLE
Fix #645: thumbnail generation for JPEG images fail with latest PHP versions (5.4-5.6)

### DIFF
--- a/core/src/plugins/editor.diaporama/PThumb.lib.php
+++ b/core/src/plugins/editor.diaporama/PThumb.lib.php
@@ -581,7 +581,7 @@ class PThumb{
                         $outputed = @imagegif($thumbnail);
                         break;
                     case 2:
-                        $outputed = @imageJPEG($thumbnail,'',100);
+                        $outputed = @imageJPEG($thumbnail,null,100);
                         break;
                     case 3:
                         $outputed = @imagepng($thumbnail);


### PR DESCRIPTION
This PR is a fix for #645. A bug in plugins/editor.diaporama/PThumb.lib.php : the second parameter of the [imagejpeg](http://php.net/manual/fr/function.imagejpeg.php) function must be either a valid filename or null, but not an empty string.

Under the latest PHP versions, using an empty string as the second parameter for imagejpeg() throws an error instead of typecasting silently.
