### PR TITLE
Unescape val column of ajxp_user_prefs when using postgresql

### DIFF
--- a/core/src/plugins/conf.sql/class.AJXP_SqlUser.php
+++ b/core/src/plugins/conf.sql/class.AJXP_SqlUser.php
@@ -361,15 +361,11 @@ class AJXP_SqlUser extends AbstractAjxpUser
             $this->setHidden(true);
         }
 
+        if ("postgre" == $this->storage->sqlDriver["driver"]) {
+            dibi::nativeQuery('SET bytea_output = escape');
+        }
         $result_prefs = dibi::query('SELECT [name], [val] FROM [ajxp_user_prefs] WHERE [login] = %s', $this->getId());
         $this->prefs = $result_prefs->fetchPairs('name', 'val');
-        if ("postgre" == $this->storage->sqlDriver["driver"]) {
-            $unescaped = array();
-            foreach($this->prefs as $name => $val) {
-                $unescaped[$name] = unserialize($val);
-            }
-            $this->prefs = $unescaped;
-        }
 
         $result_bookmarks = dibi::query('SELECT [repo_uuid], [path], [title] FROM [ajxp_user_bookmarks] WHERE [login] = %s', $this->getId());
         $all_bookmarks = $result_bookmarks->fetchAll();


### PR DESCRIPTION
User preferences are broken on postgresql. The code assumes the values loaded from the val column are not escaped but dibi does not unescape bytea values automatically. This causes an error whenever a user tries to enable WebDAV repositories.
