### PR TITLE
Name repo with accent not supported

### DIFF
--- a/core/src/core/classes/class.AJXP_Utils.php
+++ b/core/src/core/classes/class.AJXP_Utils.php
@@ -1622,9 +1622,6 @@ class AJXP_Utils
                 $options[substr($key, strlen($prefix))] = $value;
                 unset($repDef[$key]);
             } else {
-                if ($key == "DISPLAY") {
-                    $value = SystemTextEncoding::fromUTF8(AJXP_Utils::securePath($value));
-                }
                 $repDef[$key] = $value;
             }
         }

--- a/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
+++ b/core/src/plugins/access.ajxp_conf/class.ajxp_confAccessDriver.php
@@ -1326,7 +1326,7 @@ class ajxp_confAccessDriver extends AbstractAccessDriver
                 $repo = ConfService::getRepositoryById($repId);
                 $res = 0;
                 if (isSet($httpVars["newLabel"])) {
-                    $newLabel = AJXP_Utils::decodeSecureMagic($httpVars["newLabel"]);
+                    $newLabel = AJXP_Utils::sanitize(AJXP_Utils::securePath($httpVars["newLabel"]), AJXP_SANITIZE_HTML);
                     if ($this->repositoryExists($newLabel)) {
                          AJXP_XMLWriter::header();
                         AJXP_XMLWriter::sendMessage(null, $mess["ajxp_conf.50"]);


### PR DESCRIPTION
if you rename a repo or create a new one with accent in the name there is a bug in displayed name
