### PR TITLE
authfront.cas: Import Pydio user attributes (quota, name, e-mail) from CAS

### DIFF
--- a/core/src/plugins/authfront.cas/manifest.xml
+++ b/core/src/plugins/authfront.cas/manifest.xml
@@ -27,6 +27,10 @@
         <global_param expose="true" name="AUTH_PYD_MESS_STRING" group="General" type="string" label="String for Pydio auth" default="Use Pydio credential" description="This message will be appeared in login page. Ex: Use Pydio credential"/>
         <global_param expose="true" name="AUTH_CLICK_MESS_STRING" group="General" type="string" label="String for button click here" default="Click Here" description=""/>
         <global_param name="ADDITIONAL_ROLE" group="General" type="string" label="Additional roles for user logged in by CAS" default="" description="Additional roles for user logged in by CAS"/>
+        <global_param name="NAME_ATTRIBUTE" group="User attributes import (optional)" type="string" label="Display name" default="" description="CAS attribute to be used as user display name"/>
+        <global_param name="MAIL_ATTRIBUTE" group="User attributes import (optional)" type="string" label="E-mail" default="" description="CAS attribute to be used as user e-mail"/>
+        <global_param name="QUOTA_ATTRIBUTE" group="User attributes import (optional)" type="string" label="Quota" default="" description="CAS attribute to be used as user global quota"/>
+        <global_param name="QUOTA_MULTIPLIER" group="User attributes import (optional)" type="string" label="Quota multiplier" default="" description="Units (in php.ini format) used in quota attribute value: K, M, G or empty"/>
 
 
         <global_param name="CERTIFICATE_PATH" type="string" group="CONF_MESSAGE[General]"  label="CONF_MESSAGE[Certificate path]"


### PR DESCRIPTION
We have a Pydio installation where every user can have a different quota and this value is stored in CAS, so we need Pydio to get the quota value from CAS.
I found that AFAIK Pydio was not able to do that so I modified authfront.cas plugin to allow to configure it to map CAS attributes to Pydio attributes.
Currently I only added support to the ones we need: name, e-mail and quota. Also, since our CAS provides quota value in MB, I also found neccesary to provide the multiplier to be applied to the value provided by CAS to get the actual quota.
I think that this feature can be extended to include some other attributes like country and language or even custom user attributes.
Also, it currently only allows to set global quota, it may be interesting to allow to choose between global quota, repository quota, etc.