### PR TITLE
Need to reload WebDAV preferences page to get password input box to appear

### DIFF
--- a/core/src/plugins/access.ajxp_user/class.WebDAVprefsEditor.js
+++ b/core/src/plugins/access.ajxp_user/class.WebDAVprefsEditor.js
@@ -74,7 +74,7 @@ Class.create("WebDAVprefsEditor", AjxpPane, {
                         ajaxplorer.webdavCurrentPreferences = transport.responseJSON;
                         if(ajaxplorer.webdavCurrentPreferences.webdav_active){
                             if(!ajaxplorer.webdavCurrentPreferences.digest_set
-                                && ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
+                                && !ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
                                 element.down('#webdav_password_form').show();
                             }
                             ajaxplorer.displayMessage("SUCCESS", MessageHash[408]);

--- a/core/src/plugins/core.conf/standard_conf_actions.xml
+++ b/core/src/plugins/core.conf/standard_conf_actions.xml
@@ -526,7 +526,7 @@
                                     ajaxplorer.webdavCurrentPreferences = transport.responseJSON;
                                     if(ajaxplorer.webdavCurrentPreferences.webdav_active){
                                         if(!ajaxplorer.webdavCurrentPreferences.digest_set
-                                        || ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
+                                        && !ajaxplorer.webdavCurrentPreferences.webdav_force_basic) {
                                             $('webdav_password_form').show();
                                         }
                                         ajaxplorer.displayMessage("SUCCESS", MessageHash[408]);


### PR DESCRIPTION
I'm using authfronted.cas so Pydio doesn't know user password and need to ask for it after enabling WebDAV, but I found that this doesn't happen and I need to reload WebDAV preferences page to get a password input box.

To be sure that it wasn't a misconfiguration, I also set this configuration options:
```
WEBDAV_FORCE_BASIC = false
SESSION_SET_CREDENTIALS = false
TRANSMIT_CLEAR_PASS = false
```

After that, I found what I think that is wrong, the expression that checks if password form has to be shown after enabling WebDAV:

```javascript
if(!ajaxplorer.webdavCurrentPreferences.digest_set
    && ajaxplorer.webdavCurrentPreferences.webdav_force_basic)
```

It's cheking if WEBDAV_FORCE_BASIC is enabled when it should be just the opposite, shouldn't it? I mean, password form should be shown when WEBDAV_FORCE_BASIC is false and thus Digest auth is going to be used.

This is why it works after reloading the page. There, the condition is right:

```javascript
if(activator.checked && !ajaxplorer.webdavCurrentPreferences.digest_set
    && !ajaxplorer.webdavCurrentPreferences.webdav_force_basic)
```