### PR TITLE
gui.ios: wrong z-index for native client warning

### DIFF
--- a/core/src/plugins/gui.ios/manifest.xml
+++ b/core/src/plugins/gui.ios/manifest.xml
@@ -25,7 +25,7 @@
 				</script>
 			]]></template>
 			<template name="main" element="ajxp_desktop" position="top"><![CDATA[
-				<div id="browser" ajxpClass="AjxpPane" ajxpOptions='{"fit":"height","fitParent":"ajxp_desktop"}' style="text-align:center;font-size:1.1em; line-height:1.3em; font-family:Helvetica; background-color: white;">
+				<div id="browser" ajxpClass="AjxpPane" ajxpOptions='{"fit":"height","fitParent":"ajxp_desktop"}' style="text-align:center;font-size:1.1em; line-height:1.3em; font-family:Helvetica; background-color: white; z-index: 10001;">
 
 					<div style="width:90%;padding:10px; margin:0px auto;" id="message-id-1">Do you know that there is a dedicated iPhone/iPad application for Pydio?</div>
 					<a id="ajxpserver-redir" class="m-2" style="width:70%; padding:10px; margin:10px auto; font-size:0.8em;" href="#">Yes I have it already, add this server to my Pydio iOS remote servers</a><br>


### PR DESCRIPTION
That warning that appears at your first login with a smartphone doesn't have the highest z-index so some interface elemnts appear over it and the result is a little ugly and sometimes is impossible to choose an option from that popup:

![screenshot_2014-12-10-18-57-35](https://cloud.githubusercontent.com/assets/3270352/5391113/c430e0ac-8116-11e4-985d-d1afce4fcd87.png)

This happens because this popup uses "browser" id, which is the same id as the left panel. May this be the first error? I think that ids are supposed to be unique.
Anyway, this makes both panels to have the same z-index: 10000, which makes the last one to appear to be over the previous one.
Making the native-client popup to have a higher z-index will fix this issue.

Issue tested with Android and iPhone.
