### PR TITLE
Adding Italian translations for some plugins

### DIFF
--- a/core/src/plugins/editor.soundmanager/i18n/conf/it.php
+++ b/core/src/plugins/editor.soundmanager/i18n/conf/it.php
@@ -1,0 +1,25 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"Audio Player" => "Riproduttore Audio",
+"Uses HTML5 or Flash to play a sound" => "Utilizza l'HTML5 o il Flash per riprodurre una traccia audio",
+"Sound Player" => "Riproduttore Audio",
+);

--- a/core/src/plugins/editor.soundmanager/i18n/it.php
+++ b/core/src/plugins/editor.soundmanager/i18n/it.php
@@ -1,0 +1,24 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"1" => "Volume Suono",
+"2" => "Riproduttore Suono",
+);

--- a/core/src/plugins/editor.text/i18n/conf/it.php
+++ b/core/src/plugins/editor.text/i18n/conf/it.php
@@ -1,0 +1,24 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"Text Editor" => "Editor Testi",
+"Very basic text editor" => "Editor basilare per testi",
+);

--- a/core/src/plugins/editor.video/i18n/conf/it.php
+++ b/core/src/plugins/editor.video/i18n/conf/it.php
@@ -1,0 +1,24 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"Video Player" => "Riproduttore Video",
+"Inserts a video player in the info panel, either HTML5 or Flash depending on the format." => "Inserisce un riproduttore video nel pannello delle info, in HTML5 o FLASH, a seconda del formato.",
+);

--- a/core/src/plugins/editor.video/i18n/it.php
+++ b/core/src/plugins/editor.video/i18n/it.php
@@ -1,0 +1,23 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"1" => "Riproduttore Media",
+);

--- a/core/src/plugins/editor.webodf/i18n/conf/it.php
+++ b/core/src/plugins/editor.webodf/i18n/conf/it.php
@@ -1,0 +1,24 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"Open Documents Viewer" => "Visualizzatore Open Documents",
+"Open Document Formats viewer - based on WebODF.js library" => "Visualizzatore per formati Open Document - basato sulla libreria WebODF.js",
+);

--- a/core/src/plugins/editor.webodf/i18n/it.php
+++ b/core/src/plugins/editor.webodf/i18n/it.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+ * This file is part of Pydio.
+ *
+ * Pydio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <http://pyd.io/>.
+ */
+
+$mess = array(
+    "1" => "Visualizzatore Open Documents",
+    "2" => "Visualizzatore Open Documents",
+);

--- a/core/src/plugins/editor.zoho/i18n/conf/it.php
+++ b/core/src/plugins/editor.zoho/i18n/conf/it.php
@@ -1,0 +1,33 @@
+<?php
+/*
+* Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+* This file is part of Pydio.
+*
+* Pydio is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* Pydio is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+*
+* The latest code can be found at <http://pyd.io/>.
+*/
+$mess=array(
+"Zoho API Key, you must have registered to api.zoho.com" => "Chiave API Zoho; devi essere registrato ad 'api.zoho.com'",
+"API Key" => "Chiave API",
+"Zoho secret key, you must have registered to api.zoho.com" => "Chiave Segreta Zoho; devi essere registrato ad 'api.zoho.com'",
+"Secret Key" => "Chiave Segreta",
+"If you are working locally or behind a firewall, you can install an ajaxplorer Zoho Agent somewhere in the public zone. See the plugin folder content." => "Se stai lavorando localmente o protetto da un firewall, puoi installare un 'Zoho Agent' da qalche parte nella zona pubblica. Si veda il contenuto della cartella del plugin.",
+"Use Z-Agent" => "Usa Z-Agent",
+"If you use the agent, enter its URL here." => "Se utilizzi l'agent, inserisci il suo URL quì.",
+"Z-Agent URL" => "URL Z-Agent",
+"Uniquely generated public key, that you must copy and paste inside the save_zoho.php file (see doc)." => "Chiave pubblica univoca che devi copiare ed incollare nel file 'save_zoho.php' (vedi doc).",
+"Z-Agent Key" => "Chiave Z-Agent",
+"External Z-Agent" => "Z-Agent Esterno",
+);

--- a/core/src/plugins/editor.zoho/i18n/it.php
+++ b/core/src/plugins/editor.zoho/i18n/it.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Copyright 2007-2013 Charles du Jeu - Abstrium SAS <team (at) pyd.io>
+ * This file is part of Pydio.
+ *
+ * Pydio is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Pydio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Pydio.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * The latest code can be found at <http://pyd.io/>.
+ */
+$mess=array(
+    "1" => "Documenti Office",
+    "2" => "Anteprima e modifica di documenti office online",
+    "3" => "Documento Word",
+    "4" => "Presentazione",
+    "5" => "Foglio Elettronico",
+);


### PR DESCRIPTION
The Italian translations for plugins:
* 'editor.soundmanager'
* 'editor.text'
* 'editor.video'
* 'editor.webodf'
* 'editor.zoho'