### PR TITLE
Remove type strict comparison for mount_env_passwd option.

### DIFF
--- a/core/src/plugins/meta.mount/class.FilesystemMounter.php
+++ b/core/src/plugins/meta.mount/class.FilesystemMounter.php
@@ -136,11 +136,11 @@ class FilesystemMounter extends AJXP_AbstractMetaSource
 
         $cmd = ($MOUNT_SUDO? "sudo ": ""). "mount -t " .$MOUNT_TYPE. (empty( $MOUNT_OPTIONS )? " " : " -o " .$MOUNT_OPTIONS. " " ) .$UNC_PATH. " " .$MOUNT_POINT;
         $res = null;
-        if($this->getOption("MOUNT_ENV_PASSWD") === true){
+        if($this->getOption("MOUNT_ENV_PASSWD") == true){
             putenv("PASSWD=$password");
         }
         system($cmd, $res);
-        if($this->getOption("MOUNT_ENV_PASSWD") === true){
+        if($this->getOption("MOUNT_ENV_PASSWD") == true){
             putenv("PASSWD=");
         }
         if($res === null){


### PR DESCRIPTION
When setting the MOUNT_ENV_PASSWD option via the gui, the configuration is saved as either a 0 or a 1. However, the code is strict comparing against true, which fails even when the configuration is set to true in the gui. Removing the type-strictness of the comparison fixes the problem. 