### PR TITLE
Remove success for mount return code of 32 (mount failure).

### DIFF
--- a/core/src/plugins/meta.mount/class.FilesystemMounter.php
+++ b/core/src/plugins/meta.mount/class.FilesystemMounter.php
@@ -150,7 +150,7 @@ class FilesystemMounter extends AJXP_AbstractMetaSource
             $output = shell_exec($cmd1);
             $success = !empty($output);
         }else{
-            $success = ($res == 0 || $res == 32);
+            $success = ($res == 0);
         }
         if (!$success) {
             throw new Exception("Error while mounting file system!");


### PR DESCRIPTION
Mount return code 32 is 'mount failure', which should not result in meta.mount considering the mount a success. When it considers this a success, the external fs is not mounted, and files are created locally in the mount target directory. 