### PR TITLE
Update class.AJXP_Controller.php

### DIFF
--- a/core/src/core/classes/class.AJXP_Controller.php
+++ b/core/src/core/classes/class.AJXP_Controller.php
@@ -346,7 +346,7 @@ class AJXP_Controller
                     $cmd .= " --file_".$index."=".escapeshellarg($v);
                     $index++;
                 }
-            }else{
+            } else if ($key != "file") {
                 $cmd .= " --$key=".escapeshellarg($value);
             }
         }


### PR DESCRIPTION
When selecting one element and applying a background action, the selection is given twice in the parameters of $cmd, once as --file_0=element and once as --file=element. The result is that it is added twice to the archive of the powerfs functions.