### PR TITLE
Patch on WebDAV dav.php

### DIFF
--- a/core/src/dav.php
+++ b/core/src/dav.php
@@ -64,6 +64,10 @@ if (ConfService::getCoreConf("WEBDAV_BASEHOST") != "") {
 $baseURI = ConfService::getCoreConf("WEBDAV_BASEURI");
 
 $requestUri = $_SERVER["REQUEST_URI"];
+if (substr($requestUri, 0, strlen($baseURI)) != $baseURI) 
+{
+    $baseURI = substr($requestUri, 0, stripos($requestUri, $baseURI)) . $baseURI;
+}
 $end = trim(substr($requestUri, strlen($baseURI."/")));
 $rId = null;
 if ((!empty($end) || $end ==="0") && $end[0] != "?") {


### PR DESCRIPTION
If you are operating with an domain like "http://www.mydomain.com/subfolder/" you have to put this into server URL in Pydio main options in order to get proper share links etc. If you now have the WebDAV operating under "http://www.mydomain.com/subfolder/shares" you need to put "/subfolder/shares" in the Shares URI Setting of WebDAV in order to get WebDAV working. But now the link in WebDAV preferences looks like "http://www.mydomain.com/subfolder/subfolder/shares", which is wrong.
The code change let you put either "/subfolder/shares" or "/shares" put in Shares URI Setting of WebDAV to get WebDAV working and with "/shares" the WebDAV preferences looks like "http://www.mydomain.com/subfolder/shares", which is right.