### PR TITLE
S3 region EU (Frankfurt) eu-central-1

### DIFF
--- a/core/src/plugins/access.s3/class.s3AccessDriver.php
+++ b/core/src/plugins/access.s3/class.s3AccessDriver.php
@@ -58,7 +58,8 @@ class s3AccessDriver extends fsAccessDriver
             require_once("aws.phar");
             $options = array(
                 'key'    => $this->repository->getOption("API_KEY"),
-                'secret' => $this->repository->getOption("SECRET_KEY")
+                'secret' => $this->repository->getOption("SECRET_KEY"),
+                'signature' => 'v4'
             );
             $baseURL = $this->repository->getOption("STORAGE_URL");
             if(!empty($baseURL)){

--- a/core/src/plugins/access.s3/manifest.xml
+++ b/core/src/plugins/access.s3/manifest.xml
@@ -10,7 +10,7 @@
 	<server_settings>
 		<param name="API_KEY" type="string" label="CONF_MESSAGE[Key]" description="CONF_MESSAGE[S3 Api Key]" mandatory="true" default=""/>
 		<param name="SECRET_KEY" type="string" label="CONF_MESSAGE[Secret Key]" description="CONF_MESSAGE[S3 secret key]" mandatory="true"/>
-		<param name="REGION" type="select" choices="us-east-1|US Standard (Virginia),us-west-1|US West 1 (Northern California),us-west-2|US West 2 (Oregon),eu-west-1|EU (Ireland), ap-southeast-2|South-East (Sydney), ap-southeast-1|South-East (Singapore),ap-northeast-1|Asia Pacific (Japan),sa-east-1|South America (Sao Paulo),us-gov-west-1|EU Governement Cloud" label="CONF_MESSAGE[Region]" description="CONF_MESSAGE[S3 storage region]" mandatory="true"/>
+		<param name="REGION" type="select" choices="us-east-1|US Standard (Virginia),us-west-1|US West 1 (Northern California),us-west-2|US West 2 (Oregon),eu-west-1|EU (Ireland), ap-southeast-2|South-East (Sydney), ap-southeast-1|South-East (Singapore),ap-northeast-1|Asia Pacific (Japan),sa-east-1|South America (Sao Paulo),us-gov-west-1|EU Governement Cloud,eu-central-1|EU (Frankfurt)" label="CONF_MESSAGE[Region]" description="CONF_MESSAGE[S3 storage region]" mandatory="true"/>
         <param name="STORAGE_URL" type="string" label="CONF_MESSAGE[Storage URL]" description="Replace default AWS access points (built from region). Set a full URL, including protocol" mandatory="false"/>
 		<param name="CONTAINER" type="string" label="CONF_MESSAGE[Container]" description="CONF_MESSAGE[Root container in the S3 storage]" mandatory="true"/>
 	</server_settings>


### PR DESCRIPTION
Adding the region EU (Frankfurt), region-name: eu-central-1

To authenticate against the new region I had to use the signature v4 and add it to the options array. All regions support v4. Only older regions also support v2 for legacy reasons. See: http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html So there should be no regression for other regions. But some testing with other regions may be a good idea. Alternatively I could include a check and only pass the v4 option when eu-central-1 is used. 

The new eu-central-1 (Frankfurt) region is supported by aws-sdk >= 2.7.2. With some releases between 2.7.2 and 2.7.15 I had sometimes errors that the aws class was not loaded. I did not look into it further but it seems that it was an aws-sdk issue (see: . aws-sdk 2.7.15 and now 2.7.20 work flawlessly.