### PR TITLE
missing "," character in various en.php files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This is the main source code repository of Pydio (formerly AjaXplorer), containing all the PHP server and HTML5 Web GUI.
 
-* Latest Stable release : 6.0.1
+* Latest Stable release : 6.0.5
 * Latest Dev release : 5.3.4 (was RC4 for Pydio 6.0.0)
 * License: [AGPLv3](https://www.gnu.org/licenses/agpl.html)
 * Lead developer  : Charles du Jeu (cdujeu): [Github](https://github.com/cdujeu) | [Twitter](https://twitter.com/Pydio)

--- a/core/src/plugins/access.jsapi/i18n/en.php
+++ b/core/src/plugins/access.jsapi/i18n/en.php
@@ -2,5 +2,5 @@
 $mess = array(
 "1" => "Classes and Interfaces",
 "2" => "Properties and Methods",
-"3" => "Source File"
+"3" => "Source File",
 );

--- a/core/src/plugins/access.s3/i18n/conf/en.php
+++ b/core/src/plugins/access.s3/i18n/conf/en.php
@@ -28,5 +28,5 @@ $mess=array(
 "Region" => "Region",
 "S3 storage region" => "S3 storage region",
 "Container" => "Bucket",
-"Root container in the S3 storage" => "S3 bucket"
+"Root container in the S3 storage" => "S3 bucket",
 );

--- a/core/src/plugins/access.sftp_psl/i18n/conf/en.php
+++ b/core/src/plugins/access.sftp_psl/i18n/conf/en.php
@@ -28,5 +28,5 @@ $mess=array(
 "Path" => "Path",
 "Real path to the root folder on the server" => "Real path to the root folder on the server",
 "Fix Permissions" => "Fix Permissions",
-"How to handle remote permissions to be used by PHP as local permissions. See manual." => "How to handle remote permissions to be used by PHP as local permissions. See manual."
+"How to handle remote permissions to be used by PHP as local permissions. See manual." => "How to handle remote permissions to be used by PHP as local permissions. See manual.",
 );

--- a/core/src/plugins/access.swift/i18n/conf/en.php
+++ b/core/src/plugins/access.swift/i18n/conf/en.php
@@ -28,5 +28,5 @@ $mess=array(
 "Region" => "Region",
 "S3 storage region" => "S3 storage region",
 "Container" => "Bucket",
-"Root container in the S3 storage" => "S3 bucket"
+"Root container in the S3 storage" => "S3 bucket",
 );

--- a/core/src/plugins/action.disclaimer/i18n/en.php
+++ b/core/src/plugins/action.disclaimer/i18n/en.php
@@ -6,5 +6,5 @@ $mess=array(
     "1" => "Disclaimer",
     "2" => "Accept Disclaimer",
     "3" => "You must accept the general usage conditions below. Please read and use the checkbox to accept.",
-    "4" => "I therefore accept the conditions of usage"
+    "4" => "I therefore accept the conditions of usage",
 );

--- a/core/src/plugins/action.powerfs/i18n/conf/en.php
+++ b/core/src/plugins/action.powerfs/i18n/conf/en.php
@@ -21,5 +21,5 @@
 $mess = array(
     // will be replaced by the application title
     "Power FS" => "Power FS",
-    "This set of extensions assume that you have an administration access to your server: ability to tweak the webserver and the php configuration, ability to access the command line, etc." => "This set of extensions assume that you have an administration access to your server: ability to tweak the webserver and the php configuration, ability to access the command line, etc."
+    "This set of extensions assume that you have an administration access to your server: ability to tweak the webserver and the php configuration, ability to access the command line, etc." => "This set of extensions assume that you have an administration access to your server: ability to tweak the webserver and the php configuration, ability to access the command line, etc.",
 );

--- a/core/src/plugins/action.powerfs/i18n/en.php
+++ b/core/src/plugins/action.powerfs/i18n/en.php
@@ -22,5 +22,5 @@ $mess = array(
     // will be replaced by the application title
     "1" => "Creating archive, please wait",
     "2" => "Reload current folder",
-    "3" => "Archive download should start automatically"
+    "3" => "Archive download should start automatically",
 );

--- a/core/src/plugins/action.skeleton/res/i18n/en.php
+++ b/core/src/plugins/action.skeleton/res/i18n/en.php
@@ -28,5 +28,5 @@ $mess = array(
     "4" => "Modal Link",
     "5" => "Open the link in a modal dialog",
     "6" => "Dynamic content",
-    "7" => "Loading content, please wait..."
+    "7" => "Loading content, please wait...",
 );

--- a/core/src/plugins/auth.radius/i18n/conf/en.php
+++ b/core/src/plugins/auth.radius/i18n/conf/en.php
@@ -34,5 +34,5 @@ $mess=array(
 "Test password" => "Test password",
 "Password for connection testing" => "Password for connection testing",
 "Test Connection" => "Test connection",
-"Try to connect to RADIUS server" => "Try to connect to the RADIUS server"
+"Try to connect to RADIUS server" => "Try to connect to the RADIUS server",
 );

--- a/core/src/plugins/authfront.cas/i18n/conf/en.php
+++ b/core/src/plugins/authfront.cas/i18n/conf/en.php
@@ -50,5 +50,5 @@ $mess = array(
     "Proxied service who uses Proxy Ticket provided by this CAS Proxy.Ex smb://pydio.com" => "Proxied service who uses Proxy Ticket provided by this CAS Proxy.Ex smb://pydio.com",
     "PTG store mode" => "PTG store mode" ,
     "Config for Proxy Granting Ticket Storage. If is file option, location for storate is session_save_path()" => "Config for Proxy Granting Ticket Storage. If is file option, location for storate is session_save_path()",
-    "Install SQL Table (support only mysql)" => "Install SQL Table (support only mysql)"
+    "Install SQL Table (support only mysql)" => "Install SQL Table (support only mysql)",
 );

--- a/core/src/plugins/authfront.cas/i18n/en.php
+++ b/core/src/plugins/authfront.cas/i18n/en.php
@@ -20,5 +20,5 @@
  */
 
 $mess = array(
-    "1" => "Order"
+    "1" => "Order",
 );

--- a/core/src/plugins/authfront.duosecurity/i18n/en.php
+++ b/core/src/plugins/authfront.duosecurity/i18n/en.php
@@ -2,5 +2,5 @@
 
 $mess = array(
     "1" => "Dual-Form Authentication",
-    "2" => "Dual-Form Authentication"
+    "2" => "Dual-Form Authentication",
 );

--- a/core/src/plugins/authfront.keystore/i18n/en.php
+++ b/core/src/plugins/authfront.keystore/i18n/en.php
@@ -28,5 +28,5 @@ $mess = array(
     "6" => "Invalidate existing API keys",
     "7" => "Are you sure you want to revoke this/these key(s)?",
     "8" => "Key(s) removed successfully!",
-    "9" => "Devices connected to your account:"
+    "9" => "Devices connected to your account:",
 );

--- a/core/src/plugins/core.ajaxplorer/i18n/en.php
+++ b/core/src/plugins/core.ajaxplorer/i18n/en.php
@@ -633,5 +633,5 @@ $mess=array(
 "539" => "Upload error: file is partial",
 "540" => "Upload error: cannot find the temporary directory",
 "541" => "Upload error: cannot write into the temporary directory",
-"542" => "Upload error: a PHP extension stopped the upload process."
+"542" => "Upload error: a PHP extension stopped the upload process.",
 ); 

--- a/core/src/plugins/cypher.encfs/resources/i18n/en.php
+++ b/core/src/plugins/cypher.encfs/resources/i18n/en.php
@@ -24,5 +24,5 @@ $mess=array(
 "3" => "Uncypher folder",
 "4" => "Decrypt folder data",
 "5" => "Cypher folder",
-"6" => "Encrypt folder data"
+"6" => "Encrypt folder data",
 );

--- a/core/src/plugins/editor.ajxp_datagrid/i18n/en.php
+++ b/core/src/plugins/editor.ajxp_datagrid/i18n/en.php
@@ -1,5 +1,5 @@
 <?php
 $mess = array(
     "1" => "Data Grid",
-    "2" => "Spreadsheet-like visualizer"
+    "2" => "Spreadsheet-like visualizer",
 );

--- a/core/src/plugins/editor.ajxp_graphs/res/i18n/en.php
+++ b/core/src/plugins/editor.ajxp_graphs/res/i18n/en.php
@@ -1,5 +1,5 @@
 <?php
 $mess = array(
     "1" => "Analytics",
-    "2" => "Analytics Graphs Viewer"
+    "2" => "Analytics Graphs Viewer",
 );

--- a/core/src/plugins/editor.browser/resources/i18n/en.php
+++ b/core/src/plugins/editor.browser/resources/i18n/en.php
@@ -26,5 +26,5 @@ $mess=array(
     "5" => "Alternatively, you can <a>create a new bookmark to an URL</a>",
     "6" => "Enter an URL starting with http/https",
     "7" => "URL Bookmark",
-    "8" => "Enter a label for this bookmark"
+    "8" => "Enter a label for this bookmark",
 );

--- a/core/src/plugins/editor.codemirror/i18n/en.php
+++ b/core/src/plugins/editor.codemirror/i18n/en.php
@@ -29,5 +29,5 @@ $mess=array(
 "7" => "Undo",
 "8"	=> "Redo",
 "9"	=> "Text Search",
-"10" => "Indent size"
+"10" => "Indent size",
 );

--- a/core/src/plugins/editor.diaporama/i18n/conf/en.php
+++ b/core/src/plugins/editor.diaporama/i18n/conf/en.php
@@ -30,5 +30,5 @@ $mess=array(
 "Quality" => "Quality",
 "Thumbs quality" => "Thumbs quality",
 "Exif Rotation" => "Exif Rotation",
-"Rotate image using exif rotation" => "Rotate image using exif rotation"
+"Rotate image using exif rotation" => "Rotate image using exif rotation",
 );

--- a/core/src/plugins/meta.git/i18n/en.php
+++ b/core/src/plugins/meta.git/i18n/en.php
@@ -39,5 +39,5 @@ $mess = array(
     "MOVE"          => "File moved",
     "MODIFICATION"  => "Content modified",
     "DELETION"      => "File deleted",
-    "CREATION"      => "File created"
+    "CREATION"      => "File created",
 );

--- a/core/src/plugins/meta.simple_lock/i18n/en.php
+++ b/core/src/plugins/meta.simple_lock/i18n/en.php
@@ -5,5 +5,5 @@ $mess = array(
 "2" => "Lock selected item",
 "3" => "Unlock",
 "4" => "Remove lock",
-"5" => "This file is locked by another user, it is probably currently being edited, you are not allowed to modify it."
+"5" => "This file is locked by another user, it is probably currently being edited, you are not allowed to modify it.",
 );

--- a/core/src/plugins/uploader.http/resources/i18n/en.php
+++ b/core/src/plugins/uploader.http/resources/i18n/en.php
@@ -21,5 +21,5 @@ $mess = array(
     "15"=> "Or create a bookmark manually and use the code below as the link url : ",
     "16"=> "Drag me to your bookmark bar!",
     "17"=> "Download file",
-    "18"=> "Partial file"
+    "18"=> "Partial file",
 );


### PR DESCRIPTION
For translators to allow correct transfer of the .php text files to the .po format,
so that a CAT tool like OmegaT can be used to ease the translation, text lines
need to end with ",". Currently, some of the php files were missing this
character on the last text line of the file. This commit fixes this.

list of files was generated with this command
`for i in `find . -type f -name en.php`; do pcregrep -M '\"\n\)' "$i" && echo $i; done`

files for other languages than EN were not touched by me, but can be listed with this:
`for i in `find . -type f -name *.php`; do pcregrep -M '\"\n\)' "$i" && echo && echo $i; done | grep /i18n/`