### PR TITLE
Update class.AbstractAccessDriver.php

### DIFF
--- a/core/src/plugins/core.access/class.AbstractAccessDriver.php
+++ b/core/src/plugins/core.access/class.AbstractAccessDriver.php
@@ -251,7 +251,12 @@ class AbstractAccessDriver extends AJXP_Plugin
                 $error[] = $mess[114];
                 return ;
             } else {
-                AJXP_Controller::applyHook("node.change", array(new AJXP_Node($realSrcFile), new AJXP_Node($destFile), !$move));
+                //AJXP_Controller::applyHook("node.change", array(new AJXP_Node($realSrcFile), new AJXP_Node($destFile), !$move));
+                $ajxpNodeSrc = new AJXP_Node($realSrcFile);
+                $ajxpNodeSrc->setLeaf(false);
+                $ajxpNodeDst = new AJXP_Node($destFile);
+                $ajxpNodeDst->setLeaf(false);
+                AJXP_Controller::applyHook("node.change", array($ajxpNodeSrc, $ajxpNodeDst, !$move));
             }
         } else {
             if ($move) {


### PR DESCRIPTION
When cross copying folder to ftp: 
 -  error: message=ftp_get(): Access is denied
 -  reason: _metadata is not set
 - solution: indicate this is a directory with setLeaf to false