### PR TITLE
Update class.AbstractAccessDriver.php

### DIFF
--- a/core/src/plugins/core.access/class.AbstractAccessDriver.php
+++ b/core/src/plugins/core.access/class.AbstractAccessDriver.php
@@ -314,7 +314,9 @@ class AbstractAccessDriver extends AJXP_Plugin
             $dest = fopen($destFile, "w");
             if ($dest !== false) {
                 while (!feof($src)) {
-                    stream_copy_to_stream($src, $dest, 4096);
+                    //stream_copy_to_stream($src, $dest, 4096);
+                    $count = stream_copy_to_stream($src, $dest, 4096);
+                    if ($count == 0) break;
                 }
                 fclose($dest);
             }


### PR DESCRIPTION
Problem when cross copying empty files (i.e. created in Pydio with the menu entry 'Create'), when the default filecopy function is used (i.e. copying from dropbox to ftp...)
  - symptom: the file is not copied, there is an infinite loop, the condition on feof never breaks the loop.
  - reason: feof always (in php at least) return 0 when the file size is 0, because an end of file is never reached
  - solution: do not use feof to control the loop, or break when there is nothing more to copy.