### PR TITLE
Update class.AJXP_Sabre_Collection.php

### DIFF
--- a/core/src/core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_Collection.php
+++ b/core/src/core/classes/sabredav/ajaxplorer/class.AJXP_Sabre_Collection.php
@@ -153,7 +153,8 @@ class AJXP_Sabre_Collection extends AJXP_Sabre_Node implements Sabre\DAV\ICollec
             if ($file == "." || $file == "..") {
                 continue;
             }
-            if ( !$this->repository->getOption("SHOW_HIDDEN_FILES") && AJXP_Utils::isHidden($file)) {
+            //if ( !$this->repository->getOption("SHOW_HIDDEN_FILES") && AJXP_Utils::isHidden($file)) {
+            if ( !$this->getAccessDriver()->getFilteredOption("SHOW_HIDDEN_FILES") && AJXP_Utils::isHidden($file)) {    
                 continue;
             }
             if ( is_dir( $this->getUrl() . "/" . $file ) ) {


### PR DESCRIPTION
symptom: $this->repository->getOption("SHOW_HIDDEN_FILES") always return empty string
reason: SHOW_HIDDEN_FILES is a plugin option
solution: $this->getAccessDriver()->getFilteredOption("SHOW_HIDDEN_FILES").
getFilteredOption need to be public in core\classes\class.AJXP_Plugin.php(138)