### PR TITLE
Menu "Download" with PowerFS failed if accent in folder under the files selected

### DIFF
--- a/core/src/plugins/action.powerfs/class.PowerFSController.php
+++ b/core/src/plugins/action.powerfs/class.PowerFSController.php
@@ -99,7 +99,7 @@ class PowerFSController extends AJXP_Plugin
 
             case "postcompress_download":
 
-                $archive = AJXP_Utils::getAjxpTmpDir()."/".$httpVars["ope_id"]."_".$httpVars["archive_name"];
+                $archive = AJXP_Utils::getAjxpTmpDir()."/".$httpVars["ope_id"]."_".AJXP_Utils::sanitize(AJXP_Utils::decodeSecureMagic($httpVars["archive_name"]), AJXP_SANITIZE_FILENAME);
                 $fsDriver = AJXP_PluginsService::getInstance()->getUniqueActivePluginForType("access");
                 if (is_file($archive)) {
                     register_shutdown_function("unlink", $archive);

--- a/core/src/plugins/action.powerfs/class.PowerFSController.php
+++ b/core/src/plugins/action.powerfs/class.PowerFSController.php
@@ -99,7 +99,7 @@ class PowerFSController extends AJXP_Plugin
 
             case "postcompress_download":
 
-                $archive = AJXP_Utils::getAjxpTmpDir()."/".$httpVars["ope_id"]."_".AJXP_Utils::sanitize(AJXP_Utils::decodeSecureMagic($httpVars["archive_name"]), AJXP_SANITIZE_FILENAME);
+                $archive = AJXP_Utils::getAjxpTmpDir().DIRECTORY_SEPARATOR.$httpVars["ope_id"]."_".AJXP_Utils::sanitize(AJXP_Utils::decodeSecureMagic($httpVars["archive_name"]), AJXP_SANITIZE_FILENAME);
                 $fsDriver = AJXP_PluginsService::getInstance()->getUniqueActivePluginForType("access");
                 if (is_file($archive)) {
                     register_shutdown_function("unlink", $archive);
@@ -161,9 +161,8 @@ class PowerFSController extends AJXP_Plugin
                     }
                 }
                 $cmdSeparator = ((PHP_OS == "WIN32" || PHP_OS == "WINNT" || PHP_OS == "Windows")? "&" : ";");
-                //$archiveName = SystemTextEncoding::fromUTF8($httpVars["archive_name"]);
                 if (!$compressLocally) {
-                    $archiveName = AJXP_Utils::getAjxpTmpDir()."/".$httpVars["ope_id"]."_".$archiveName;
+                    $archiveName = AJXP_Utils::getAjxpTmpDir().DIRECTORY_SEPARATOR.$httpVars["ope_id"]."_".$archiveName;
                 }
                 chdir($rootDir);
                 $cmd = $this->getFilteredOption("ZIP_PATH")." -r ".escapeshellarg($archiveName)." ".implode(" ", $args);


### PR DESCRIPTION
Menu "Download" with PowerFS failed if accent in folder under the files selected
Because in this case archive_name has accent