### PR TITLE
Fixed logic to check if a file can be written to

### DIFF
--- a/core/src/plugins/editor.text/class.TextEditor.js
+++ b/core/src/plugins/editor.text/class.TextEditor.js
@@ -104,7 +104,7 @@ Class.create("TextEditor", AbstractEditor, {
 	},
 	
 	parseXml : function(transport){
-		if(parseInt(transport.responseText).toString() == transport.responseText){
+                if(transport.responseText != "The file has been saved successfully"){
 			alert("Cannot write the file to disk (Error code : "+transport.responseText+")");
 		}else{
 			this.setModified(false);


### PR DESCRIPTION
Logic before was checking for error code in response however some error messages don't have the error code in them such as the simple lock error messages.

I haven't played around much with pydio to know what is the proper array to index for error messages so feel free to change to the correct array with the appropriate index for the constant I used in the if statement.