### PR TITLE
file name encoding when downloading in mode IE 11

### DIFF
--- a/core/src/core/classes/class.HTMLWriter.php
+++ b/core/src/core/classes/class.HTMLWriter.php
@@ -157,7 +157,7 @@ class HTMLWriter
      */
     public static function generateAttachmentsHeader(&$attachmentName, $dataSize, $isFile=true, $gzip=false)
     {
-        if (preg_match('/ MSIE /',$_SERVER['HTTP_USER_AGENT']) || preg_match('/ WebKit /',$_SERVER['HTTP_USER_AGENT'])) {
+        if (preg_match('/ MSIE /',$_SERVER['HTTP_USER_AGENT']) || preg_match('/ WebKit /',$_SERVER['HTTP_USER_AGENT']) || preg_match(‘/ Trident/’,$_SERVER[‘HTTP_USER_AGENT’])) {
              $attachmentName = str_replace("+", " ", urlencode(SystemTextEncoding::toUTF8($attachmentName)));
          }
 


### PR DESCRIPTION
In IE 11, There was a problem that file name encoding when downloading files in non-compatibility mode.

IE 11 is needed to User-Agent check 'Trident'.

So I Add 'preg_match' to check 'Trident'

I only tested Korean Language,

but I hope it will work in other language.

Thanks!