### PR TITLE
Update class.ftpAccessWrapper.php

### DIFF
--- a/core/src/plugins/access.ftp/class.ftpAccessWrapper.php
+++ b/core/src/plugins/access.ftp/class.ftpAccessWrapper.php
@@ -467,7 +467,7 @@ class ftpAccessWrapper implements AjxpWrapper
             $parts = AJXP_Utils::safeParseUrl($url);
         }
         $serverPath = AJXP_Utils::securePath("/$this->path/".$parts["path"]);
-        return "ftp".($this->secure?"s":"")."://$this->user:$this->password@$this->host:$this->port".$serverPath;
+        return "ftp".($this->secure?"s":"")."://$this->user:".urlencode($this->password)."@$this->host:$this->port".$serverPath;
     }
 
     /** This method retrieves the FTP server features as described in RFC2389


### PR DESCRIPTION
problems containing "/" in passwords, so we can use urlencode()

see https://pyd.io/f/topic/ftpaccesswrapper-problems-with-passwords-containing/