### PR TITLE
MIME type based on entire file

### DIFF
--- a/core/src/plugins/editor.browser/class.FileMimeSender.php
+++ b/core/src/plugins/editor.browser/class.FileMimeSender.php
@@ -72,7 +72,7 @@ class FileMimeSender extends AJXP_Plugin
 
             //Get mimetype with fileinfo PECL extension
             if (class_exists("finfo")) {
-                $finfo = finfo_open(FILEINFO_MIME);
+                $finfo = new finfo(FILEINFO_MIME);
                 $fileMime = $finfo->buffer(fread($fp, 2000));
             }
             //Get mimetype with (deprecated) mime_content_type

--- a/core/src/plugins/editor.browser/class.FileMimeSender.php
+++ b/core/src/plugins/editor.browser/class.FileMimeSender.php
@@ -72,10 +72,9 @@ class FileMimeSender extends AJXP_Plugin
 
             //Get mimetype with fileinfo PECL extension
             if (class_exists("finfo")) {
-				$finfo = finfo_open(FILEINFO_MIME);
-				$fileMime = finfo_file($finfo, $repository->options['PATH'] . $repository->getDisplay());
-				finfo_close($finfo);
-			}
+                $finfo = finfo_open(FILEINFO_MIME);
+                $fileMime = $finfo->buffer(fread($fp, 2000));
+            }
             //Get mimetype with (deprecated) mime_content_type
             if (strpos($fileMime, "application/octet-stream")===0 && function_exists("mime_content_type")) {
                 $fileMime = @mime_content_type($fp);

--- a/core/src/plugins/editor.browser/class.FileMimeSender.php
+++ b/core/src/plugins/editor.browser/class.FileMimeSender.php
@@ -72,9 +72,10 @@ class FileMimeSender extends AJXP_Plugin
 
             //Get mimetype with fileinfo PECL extension
             if (class_exists("finfo")) {
-                $finfo = new finfo(FILEINFO_MIME);
-                $fileMime = $finfo->buffer(fread($fp, 100));
-            }
+				$finfo = finfo_open(FILEINFO_MIME);
+				$fileMime = finfo_file($finfo, $repository->options['PATH'] . $repository->getDisplay());
+				finfo_close($finfo);
+			}
             //Get mimetype with (deprecated) mime_content_type
             if (strpos($fileMime, "application/octet-stream")===0 && function_exists("mime_content_type")) {
                 $fileMime = @mime_content_type($fp);


### PR DESCRIPTION
Changed finfo from examining just file header to examining entire file to determine correct content type.  Problem: .docx files are essentially zip files. Original code would only look at header an determine docx was type application/zip.  IE obeys this content type when downloading the file and renames the extension (example.docx -> example.zip).  Submitted code gets the file location from the repository object and uses finfo on that, generating the correct content type.