### PR TITLE
fix preview with unoconv of files with russian names

### DIFF
--- a/core/src/plugins/editor.imagick/class.IMagickPreviewer.php
+++ b/core/src/plugins/editor.imagick/class.IMagickPreviewer.php
@@ -282,6 +282,7 @@ class IMagickPreviewer extends AJXP_Plugin
                 } else {
                     $unoconv =  "HOME=/tmp ".$unoconv." --stdout -f pdf ".escapeshellarg($masterFile)." > ".escapeshellarg(basename($unoDoc));
                 }
+                putenv('LC_CTYPE='.AJXP_LOCALE);
                 exec($unoconv, $out, $return);
             }
             if (is_file($unoDoc)) {


### PR DESCRIPTION
This patch fix issue with pydio 6.0.8, when preview works fine for .doc and .xls files with names contains no russian characters, but fails to preview for filenames with such characters.
Preview of .pdf files works with russian filenames with and without this patch.