### PR TITLE
Add composer.json to install OpenStack SDK in access.swift plugin

### DIFF
--- a/core/src/plugins/access.swift/openstack-sdk-php/composer.json
+++ b/core/src/plugins/access.swift/openstack-sdk-php/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "pydio/openstack-sdk-php",
+  "description": "This will install the last published commit of the prototype OpenStack SDK before it was EOL.",
+  "type": "metapackage",
+  "authors": [
+    {
+      "name": "Robert McKenney",
+      "email": "robert@mckenney.ca"
+    }
+  ],
+  "minimum-stability": "dev",
+
+  "require-dev": {
+    "openstack/openstack-sdk-php": "dev-master#4536bbc166ada96ff2a3a5a4b6e636b093103f0e"
+  }
+}


### PR DESCRIPTION
When you run `composer install` in the *openstack-sdk-php* directory, this will install the last good commit before the project was declared EOL and ensure the dependency files including the autoloader are in the expected locations.