### PR TITLE
file or folder was moved ?

### DIFF
--- a/core/src/plugins/core.access/class.AbstractAccessDriver.php
+++ b/core/src/plugins/core.access/class.AbstractAccessDriver.php
@@ -280,6 +280,8 @@ class AbstractAccessDriver extends AJXP_Plugin
             }
             if (isset($dirRes)) {
                 $success[] = $mess[117]." ".SystemTextEncoding::toUTF8(basename($srcFile))." ".$messagePart." (".SystemTextEncoding::toUTF8($dirRes)." ".$mess[116].") ";
+            } else if (is_dir($destFile)) {
+                $success[] = $mess[117]." ".SystemTextEncoding::toUTF8(basename($srcFile))." ".$messagePart;
             } else {
                 $success[] = $mess[34]." ".SystemTextEncoding::toUTF8(basename($srcFile))." ".$messagePart;
             }


### PR DESCRIPTION
fix the message when a file  or a folder was moved
otherwise always display "the file" ... was moved to