### PR TITLE
umlaut or accent in filename fix

### DIFF
--- a/core/src/plugins/editor.imagick/class.IMagickPreviewer.php
+++ b/core/src/plugins/editor.imagick/class.IMagickPreviewer.php
@@ -279,7 +279,9 @@ class IMagickPreviewer extends AJXP_Plugin
                 if (stripos(PHP_OS, "win") === 0) {
                     $unoconv = $this->pluginConf["UNOCONV"]." -o ".escapeshellarg(basename($unoDoc))." -f pdf ".escapeshellarg($masterFile);
                 } else {
-                    $unoconv =  "HOME=/tmp ".$unoconv." --stdout -f pdf ".escapeshellarg($masterFile)." > ".escapeshellarg(basename($unoDoc));
+                    $lc_all  = defined("AJXP_LOCALE") ? " LC_ALL=".AJXP_LOCALE." " : "";
+                    $unoconv =  "HOME=/tmp ".$lc_all.$unoconv." --stdout -f pdf ".escapeshellarg($masterFile) ." > ".escapeshellarg(basename($unoDoc));
+                    
                 }
                 putenv('LC_CTYPE='.AJXP_LOCALE);
                 exec($unoconv, $out, $return);


### PR DESCRIPTION
Files cannot be converted for Preview by ImageMagick cause of malformed Filenames.

Báz.docx becomes B\udcc3\udca1z.docx

Set LC_ALL= to your defined Language fixes the issue.