### PR TITLE
Develop fix1020

### DIFF
--- a/core/src/plugins/gui.ajax/res/js/ui/prototype/class.PydioUI.js
+++ b/core/src/plugins/gui.ajax/res/js/ui/prototype/class.PydioUI.js
@@ -557,9 +557,10 @@ Class.create("PydioUI", {
     updateI18nTags: function(){
         var messageTags = $$('[ajxp_message_id]');
         messageTags.each(function(tag){
-            var messageId = tag.getAttribute("ajxp_message_id");
+            var messageId = tag.getAttribute("ajxp_message_id")
+             mH = this._pydio.MessageHash;
             try{
-                tag.update(MessageHash[messageId]);
+                tag.update(mH[messageId]);
             }catch(e){}
         });
     },

--- a/core/src/plugins/gui.ajax/res/js/ui/prototype/class.PydioUI.js
+++ b/core/src/plugins/gui.ajax/res/js/ui/prototype/class.PydioUI.js
@@ -557,7 +557,7 @@ Class.create("PydioUI", {
     updateI18nTags: function(){
         var messageTags = $$('[ajxp_message_id]');
         messageTags.each(function(tag){
-            var messageId = tag.getAttribute("ajxp_message_id")
+            var messageId = tag.getAttribute("ajxp_message_id"),
              mH = this._pydio.MessageHash;
             try{
                 tag.update(mH[messageId]);


### PR DESCRIPTION
Posible solution to issue #1020 .
MessageHash contains default language strings.
It should be accessed via this._pydio in order to get new selected language strings.
