### PR TITLE
PHP 7 constructor rename

### DIFF
--- a/core/src/core/classes/class.AJXP_Cache.php
+++ b/core/src/core/classes/class.AJXP_Cache.php
@@ -84,8 +84,7 @@ class AJXP_Cache
      * @param null $idComputerCallback
      * @return void
      */
-    public function AJXP_Cache($pluginId, $filepath, $dataCallback, $idComputerCallback = NULL)
-    {
+    function __construct($pluginId, $filepath, $dataCallback, $idComputerCallback = NULL) {
         $this->cacheDir = (defined('AJXP_SHARED_CACHE_DIR')?AJXP_SHARED_CACHE_DIR:AJXP_CACHE_DIR);
         $this->masterFile = $filepath;
         $this->dataCallback = $dataCallback;

--- a/core/src/plugins/editor.diaporama/PThumb.lib.php
+++ b/core/src/plugins/editor.diaporama/PThumb.lib.php
@@ -132,7 +132,7 @@ class PThumb{
 	     * The class constructor.
 	     * @access public
 	     */
-    function PThumb($quality,$exifrotation){
+    function __construct($quality, $exifrotation) {
     	$this->thumb_quality = $quality;
     	$this->exif_rotation = $exifrotation;
 		$this -> error_array["fatal"] = array();


### PR DESCRIPTION
See http://php.net/manual/de/migration70.deprecated.php:

---
PHP 4 style constructors (methods that have the same name as the class they are defined in) are deprecated, and will be removed in the future. 
PHP 7 will emit E_DEPRECATED if a PHP 4 constructor is the only constructor defined within a class. Classes that implement a __construct() method are unaffected.


and p.s.: The requested page "/en/community/contribute/cla" could not be found. ;)