### PR TITLE
patch multi shorten url plugin, change goo.gl service url

### DIFF
--- a/core/src/plugins/shorten.multi/class.multiShortener.php
+++ b/core/src/plugins/shorten.multi/class.multiShortener.php
@@ -90,7 +90,7 @@ class multiShortener extends AJXP_Plugin
                     )
                 );
 
-                $goourl = 'https://www.googleapis.com/urlshortener/v1/url';
+                $goourl = 'https://www.googleapis.com/urlshortener/v1/url?key='.$type["GOOGL_APIKEY"];
                 $context  = stream_context_create( $options );
                 $result = file_get_contents( $goourl, false, $context );
                 $json = (array) json_decode( $result );


### PR DESCRIPTION
Multi URL Shortener's Goo.gl service url is now deprecated.
So, I patch that goo.gl service api url.
Just one line fix.

reference:
https://pydio.com/docs/references/plugins/shorten/multi/
https://pydio.com/forum/f/topic/multi-shorten-doesnt-work-anymore/