### PR TITLE
Bugfixes to SMB auth

### DIFF
--- a/core/src/plugins/auth.smb/class.smbAuthDriver.php
+++ b/core/src/plugins/auth.smb/class.smbAuthDriver.php
@@ -56,7 +56,12 @@ class smbAuthDriver extends AbstractAuthDriver
 
     public function checkPassword($login, $pass, $seed)
     {
-       require_once(AJXP_INSTALL_PATH."/".AJXP_PLUGINS_FOLDER."/access.smb/smb.php");
+        if(!defined('SMB4PHP_SMBCLIENT'))
+        {
+            define('SMB4PHP_SMBCLIENT', $this->pluginConf["SMBCLIENT"]);
+        }
+
+        require_once(AJXP_INSTALL_PATH."/".AJXP_PLUGINS_FOLDER."/access.smb/smb.php");
 
         $_SESSION["AJXP_SESSION_REMOTE_PASS"] = $pass;
         $repoId = $this->options["REPOSITORY_ID"];
@@ -74,7 +79,7 @@ class smbAuthDriver extends AbstractAuthDriver
         }
         $strTmp = "$login:$pass@".$host."/".$basePath."/";
         $strTmp = str_replace("//", "/",$strTmp);
-        $url = "smb://".$strTmp;
+        $url = "smbclient://".$strTmp;
         try {
             if (!is_dir($url)) {
                 $this->logDebug("SMB Login failure");

--- a/core/src/plugins/auth.smb/manifest.xml
+++ b/core/src/plugins/auth.smb/manifest.xml
@@ -8,6 +8,7 @@
 	<server_settings>
 		<param name="REPOSITORY_ID" type="select" choices="json_list:list_all_repositories_json" label="CONF_MESSAGE[Workspace]" description="CONF_MESSAGE[ID of the workspace used to validate credentials]" mandatory="true"/>
 		<param name="ADMIN_USER" type="string" label="CONF_MESSAGE[Admin user]" description="CONF_MESSAGE[The ID of an existing admin for Pydio (using conf.serial)]" mandatory="true"/>
+        <global_param name="SMBCLIENT" type="string" label="CONF_MESSAGE[Smbclient]" description="CONF_MESSAGE[Path to smbclient executable, considered to be in the path by default.]" mandatory="true" default="smbclient"/>
 	</server_settings>
 	<class_definition filename="plugins/auth.smb/class.smbAuthDriver.php" classname="smbAuthDriver"/>
 	<registry_contributions>


### PR DESCRIPTION
- Registered stream is smbclient://, not smb://, resulting in a hard error when trying to talk to smb://.
- smbclient binary path could not be set for auth plugin, resulting in the binary not being found on some systems. This is now a global setting, just as it is for the access.smb plugin.