### PR TITLE
Update class.SystemTextEncoding.php

### DIFF
--- a/core/src/core/classes/class.SystemTextEncoding.php
+++ b/core/src/core/classes/class.SystemTextEncoding.php
@@ -152,16 +152,21 @@ class SystemTextEncoding
      */
     public static function isUtf8($string)
     {
-        return preg_match('%^(?:
+       if(preg_match('%^(?:
           [\x09\x0A\x0D\x20-\x7E]            # ASCII
-        | [\xC2-\xDF][\x80-\xBF]             # non-overlong 2-byte
         | \xE0[\xA0-\xBF][\x80-\xBF]         # excluding overlongs
         | [\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}  # straight 3-byte
         | \xED[\x80-\x9F][\x80-\xBF]         # excluding surrogates
         | \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
         | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
         | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
-            )*$%xs', $string);
+            )*$%xs', $string))
+       		return true;
+
+       	return preg_match('%^(?:
+       		[\xC2-\xDF][\x80-\xBF]			# non-overlong 2-byte
+       		)*$%xs',$string) &&
+       		!mb_check_encoding($string,SystemTextEncoding::getEncoding());
     }
     /**
      * Transform a string from current Storage charset to utf8


### PR DESCRIPTION
Bug: A folder with name "学习目录" under windows using encoding cp936 turned into "ѧϰĿ¼" in web interface.

Cause: A string in other encoding than utf-8 may be matched by "[\xC2-\xDF][\x80-\xBF]". So if a string matched utf-8 pattern and is valid in local encoding, treat it as local encoding.