### PR TITLE
Resolve AJXP_Exception deprecation warning

### DIFF
--- a/core/src/publicLet.inc.php
+++ b/core/src/publicLet.inc.php
@@ -34,7 +34,7 @@ $fakes = '
 // Non working exception class
 class AJXP_Exception extends Exception
 {
-    public function AJXP_Exception($msg) { echo "$msg"; exit(); }
+    public function __construct($msg) { echo "$msg"; exit(); }
 }';
 
 eval($fakes);


### PR DESCRIPTION
Methods with the same name as their class are deprecated