### PR TITLE
Fix file name in ZOHO editor

### DIFF
--- a/core/src/plugins/editor.zoho/class.ZohoEditor.php
+++ b/core/src/plugins/editor.zoho/class.ZohoEditor.php
@@ -147,7 +147,7 @@ class ZohoEditor extends AJXP_Plugin
                 'apikey' => $this->getFilteredOption("ZOHO_API_KEY", $repository),
                 'output' => 'url',
                 'lang' => "en",
-                'filename' => urlencode(basename($file)),
+                'filename' => SystemTextEncoding::toUTF8(basename($file)),
                 'persistence' => 'false',
                 'format' => $extension,
                 'mode' => 'normaledit',


### PR DESCRIPTION
Fix file name in zoho editor in :
- title
- file name proposed with export tools

before

![2016-03-17_212010](https://cloud.githubusercontent.com/assets/3939543/13860017/9abaa500-ec86-11e5-9e03-9d051fd352bf.png)

after

![2016-03-17_205958](https://cloud.githubusercontent.com/assets/3939543/13860019/9d740f48-ec86-11e5-8768-c0a5d04e61a4.png)




