### PR TITLE
Mail Notification not fully encoded UTF-8

### DIFF
--- a/core/src/plugins/core.notifications/class.AJXP_Notification.php
+++ b/core/src/plugins/core.notifications/class.AJXP_Notification.php
@@ -120,7 +120,6 @@ class AJXP_Notification
         if($replaces["AJXP_NODE_LABEL"]==$em.$me || $replaces["AJXP_NODE_LABEL"] == $em."/".$me ){
             $replaces["AJXP_NODE_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }
-		
         if($replaces["AJXP_PARENT_LABEL"] == $em.$me || $replaces["AJXP_PARENT_LABEL"] == $em."/".$me ){
             $replaces["AJXP_PARENT_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }

--- a/core/src/plugins/core.notifications/class.AJXP_Notification.php
+++ b/core/src/plugins/core.notifications/class.AJXP_Notification.php
@@ -120,6 +120,7 @@ class AJXP_Notification
         if($replaces["AJXP_NODE_LABEL"]==$em.$me || $replaces["AJXP_NODE_LABEL"] == $em."/".$me ){
             $replaces["AJXP_NODE_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }
+        $replaces["AJXP_NODE_LABEL"] = SystemTextEncoding::toUTF8($replaces["AJXP_NODE_LABEL"]);
         if($replaces["AJXP_PARENT_LABEL"] == $em.$me || $replaces["AJXP_PARENT_LABEL"] == $em."/".$me ){
             $replaces["AJXP_PARENT_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }

--- a/core/src/plugins/core.notifications/class.AJXP_Notification.php
+++ b/core/src/plugins/core.notifications/class.AJXP_Notification.php
@@ -121,6 +121,7 @@ class AJXP_Notification
             $replaces["AJXP_NODE_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }
         $replaces["AJXP_NODE_LABEL"] = SystemTextEncoding::toUTF8($replaces["AJXP_NODE_LABEL"]);
+
         if($replaces["AJXP_PARENT_LABEL"] == $em.$me || $replaces["AJXP_PARENT_LABEL"] == $em."/".$me ){
             $replaces["AJXP_PARENT_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }

--- a/core/src/plugins/core.notifications/class.AJXP_Notification.php
+++ b/core/src/plugins/core.notifications/class.AJXP_Notification.php
@@ -120,6 +120,7 @@ class AJXP_Notification
         if($replaces["AJXP_NODE_LABEL"]==$em.$me || $replaces["AJXP_NODE_LABEL"] == $em."/".$me ){
             $replaces["AJXP_NODE_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }
+        $replaces["AJXP_NODE_LABEL"] = SystemTextEncoding::toUTF8($replaces["AJXP_NODE_LABEL"]);
 		
         if($replaces["AJXP_PARENT_LABEL"] == $em.$me || $replaces["AJXP_PARENT_LABEL"] == $em."/".$me ){
             $replaces["AJXP_PARENT_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];

--- a/core/src/plugins/core.notifications/class.AJXP_Notification.php
+++ b/core/src/plugins/core.notifications/class.AJXP_Notification.php
@@ -120,7 +120,6 @@ class AJXP_Notification
         if($replaces["AJXP_NODE_LABEL"]==$em.$me || $replaces["AJXP_NODE_LABEL"] == $em."/".$me ){
             $replaces["AJXP_NODE_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }
-        $replaces["AJXP_NODE_LABEL"] = SystemTextEncoding::toUTF8($replaces["AJXP_NODE_LABEL"]);
 		
         if($replaces["AJXP_PARENT_LABEL"] == $em.$me || $replaces["AJXP_PARENT_LABEL"] == $em."/".$me ){
             $replaces["AJXP_PARENT_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];

--- a/core/src/plugins/core.notifications/class.AJXP_Notification.php
+++ b/core/src/plugins/core.notifications/class.AJXP_Notification.php
@@ -120,6 +120,7 @@ class AJXP_Notification
         if($replaces["AJXP_NODE_LABEL"]==$em.$me || $replaces["AJXP_NODE_LABEL"] == $em."/".$me ){
             $replaces["AJXP_NODE_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }
+		
         if($replaces["AJXP_PARENT_LABEL"] == $em.$me || $replaces["AJXP_PARENT_LABEL"] == $em."/".$me ){
             $replaces["AJXP_PARENT_LABEL"] = $replaces["AJXP_REPOSITORY_LABEL"];
         }


### PR DESCRIPTION
This PR fixe charset bug with Win OS : 
- in mail notification
- alert description in left panel

**avant**

![2016-04-06_155558](https://cloud.githubusercontent.com/assets/3939543/14319687/63652e54-fc12-11e5-94d5-7499787c0679.png)

![2016-04-06_154913](https://cloud.githubusercontent.com/assets/3939543/14319642/376b6930-fc12-11e5-9968-e0b182388deb.png)

**Après**

![2016-04-06_155519](https://cloud.githubusercontent.com/assets/3939543/14319653/41701476-fc12-11e5-822f-60d50bf5ae45.png)
![2016-04-06_155340](https://cloud.githubusercontent.com/assets/3939543/14319648/3d07b4b6-fc12-11e5-810b-7e7eaaf9ab75.png)

