### PR TITLE
Display close icon for versioning plugins

### DIFF
--- a/core/src/plugins/gui.ajax/res/themes/orbit/css/pydio.css
+++ b/core/src/plugins/gui.ajax/res/themes/orbit/css/pydio.css
@@ -4854,7 +4854,9 @@ div.dialogBox.form-originalUploadForm #modalCloseBtn,
 div.dialogBox.form-jumploader_form #modalCloseBtn,
 div.dialogBox.form-external_download #modalCloseBtn,
 div.dialogBox.form-smplayer_editor #modalCloseBtn,
-div.dialogBox.form-plupload_form #modalCloseBtn {
+div.dialogBox.form-plupload_form #modalCloseBtn,
+div.dialogBox.form-history_box #modalCloseBtn,
+div.dialogBox.form-svnlog_box #modalCloseBtn {
   display: block;
   color: rgba(0, 0, 0, 0.53);
 }

--- a/core/src/plugins/gui.ajax/res/themes/orbit/css/theme/dialogs.less
+++ b/core/src/plugins/gui.ajax/res/themes/orbit/css/theme/dialogs.less
@@ -86,7 +86,9 @@ div.dialogBox.form-originalUploadForm,
 div.dialogBox.form-jumploader_form,
 div.dialogBox.form-external_download,
 div.dialogBox.form-smplayer_editor,
-div.dialogBox.form-plupload_form
+div.dialogBox.form-plupload_form,
+div.dialogBox.form-history_box,
+div.dialogBox.form-svnlog_box
 {
   #modalCloseBtn{
     display: block;


### PR DESCRIPTION
Modal dialog with version info can not be closed (git and svn plugin)

Same problem as with the audio player:
https://github.com/pydio/pydio-core/issues/1156