### PR TITLE
All message in table ajxp_log truncated, if accent in path or file name (win OS)

### DIFF
--- a/core/src/core/classes/class.AJXP_Controller.php
+++ b/core/src/core/classes/class.AJXP_Controller.php
@@ -348,7 +348,7 @@ class AJXP_Controller
                   $tmpBat = implode(DIRECTORY_SEPARATOR, array( $basePath, "data","tmp", md5(time()).".bat"));
                   $cmd = "@chcp 1252 > nul \r\n".$cmd;
                   $cmd .= "\n DEL ".chr(34).$tmpBat.chr(34);
-                  AJXP_Logger::debug("Writing file $cmd to $tmpBat");
+                  AJXP_Logger::debug("Writing file ".SystemTextEncoding::toUTF8($cmd)." to $tmpBat);
                   file_put_contents($tmpBat, $cmd);
                   pclose(popen('start /b "CLI" "'.$tmpBat.'"', 'r'));
               }

--- a/core/src/core/classes/class.AJXP_Controller.php
+++ b/core/src/core/classes/class.AJXP_Controller.php
@@ -348,7 +348,7 @@ class AJXP_Controller
                   $tmpBat = implode(DIRECTORY_SEPARATOR, array( $basePath, "data","tmp", md5(time()).".bat"));
                   $cmd = "@chcp 1252 > nul \r\n".$cmd;
                   $cmd .= "\n DEL ".chr(34).$tmpBat.chr(34);
-                  AJXP_Logger::debug("Writing file ".SystemTextEncoding::toUTF8($cmd)." to $tmpBat);
+                  AJXP_Logger::debug("Writing file ".SystemTextEncoding::toUTF8($cmd)." to $tmpBat");
                   file_put_contents($tmpBat, $cmd);
                   pclose(popen('start /b "CLI" "'.$tmpBat.'"', 'r'));
               }

--- a/core/src/plugins/access.fs/class.fsAccessDriver.php
+++ b/core/src/plugins/access.fs/class.fsAccessDriver.php
@@ -212,14 +212,14 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
             $orig_files = $selection->files;
         elseif (is_string($selection))
             // As passed by destination parameter
-            return $this->repository->slug.$selection;
+            return SystemTextEncoding::toUTF8($this->repository->slug.$selection);
         else
             // Unrecognized
             return $selection;
 
         $files = array();
         foreach ($orig_files as $file)
-            $files[] = $this->repository->slug.$file;
+            $files[] = SystemTextEncoding::toUTF8($this->repository->slug.$file);
         return $files;
     }
 
@@ -579,7 +579,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                 if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
                 if($dest == null) $dest = AJXP_Utils::safeDirname($file);
                 $nodesDiffs["UPDATE"][$file] = new AJXP_Node($this->urlBase.$dest."/".$filename_new);
-                $this->logInfo("Rename", array("files"=>$this->addSlugToPath($file), "original"=>$this->addSlugToPath($file), "new"=>$filename_new));
+                $this->logInfo("Rename", array("files"=>$this->addSlugToPath($file), "original"=>$this->addSlugToPath($file), "new"=>SystemTextEncoding::toUTF8($filename_new)));
 
             break;
 
@@ -619,7 +619,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                     $messages[] = $messtmp;
                     $newNode = new AJXP_Node($this->urlBase.$parentDir."/".$basename);
                     array_push($nodesDiffs["ADD"], $newNode);
-                    $this->logInfo("Create Dir", array("dir"=>$this->addSlugToPath($parentDir)."/".$basename, "files"=>$this->addSlugToPath($parentDir)."/".$basename));
+                    $this->logInfo("Create Dir", array("dir"=>$this->addSlugToPath($parentDir)."/".SystemTextEncoding::toUTF8($basename), "files"=>$this->addSlugToPath($parentDir)."/".SystemTextEncoding::toUTF8($basename)));
                 }
                 if(count($errors)){
                     if(!count($messages)){
@@ -663,7 +663,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                 $logMessage = $messtmp;
                 //$reloadContextNode = true;
                 //$pendingSelection = $dir."/".$filename;
-                $this->logInfo("Create File", array("files"=>$this->addSlugToPath($dir)."/".$filename));
+                $this->logInfo("Create File", array("files"=>$this->addSlugToPath($dir)."/".SystemTextEncoding::toUTF8($filename)));
                 $newNode = new AJXP_Node($this->urlBase.$dir."/".$filename);
                 if(!isSet($nodesDiffs)) $nodesDiffs = $this->getNodesDiffArray();
                 array_push($nodesDiffs["ADD"], $newNode);
@@ -794,7 +794,7 @@ class fsAccessDriver extends AbstractAccessDriver implements AjxpWrapperProvider
                         clearstatcache(true, $createdNode->getUrl());
                         $createdNode->loadNodeInfo(true);
                         $logMessage.="$mess[34] ".SystemTextEncoding::toUTF8($userfile_name)." $mess[35] $dir";
-                        $logFile = $this->addSlugToPath(SystemTextEncoding::fromUTF8($dir))."/".$userfile_name;
+                        $logFile = $this->addSlugToPath($dir)."/".SystemTextEncoding::toUTF8($userfile_name);
                         $this->logInfo("Upload File", array("file"=>$logFile, "files"=> $logFile ) );
 
                         if($partialUpload){

--- a/core/src/plugins/core.ajaxplorer/i18n/fr.php
+++ b/core/src/plugins/core.ajaxplorer/i18n/fr.php
@@ -642,8 +642,8 @@ $mess=array(
 "546" => "Ce partage provient de %%OWNER%% d'un système distant. Souhaîtez-vous continuer ?",
 "547" => "Accepter",
 "548" => "Refuser",
-    "549" => "Vaous avez précedemment accepté ce partage depuis un système distant (par %%OWNER%%). Désirez-vous le rejeter désormais?",
-    "550" => "Rejeter ce partage",
-    "551" => "Rejeter",
+"549" => "Vaous avez précedemment accepté ce partage depuis un système distant (par %%OWNER%%). Désirez-vous le rejeter désormais?",
+"550" => "Rejeter ce partage",
+"551" => "Rejeter",
 /* END SENTENCE */
 );

--- a/core/src/plugins/core.ajaxplorer/i18n/fr.php
+++ b/core/src/plugins/core.ajaxplorer/i18n/fr.php
@@ -642,7 +642,7 @@ $mess=array(
 "546" => "Ce partage provient de %%OWNER%% d'un système distant. Souhaîtez-vous continuer ?",
 "547" => "Accepter",
 "548" => "Refuser",
-"549" => "Vaous avez précedemment accepté ce partage depuis un système distant (par %%OWNER%%). Désirez-vous le rejeter désormais?",
+"549" => "Vous avez précedemment accepté ce partage depuis un système distant (par %%OWNER%%). Désirez-vous le rejeter désormais?",
 "550" => "Rejeter ce partage",
 "551" => "Rejeter",
 /* END SENTENCE */

--- a/core/src/plugins/core.index/class.CoreIndexer.php
+++ b/core/src/plugins/core.index/class.CoreIndexer.php
@@ -53,7 +53,7 @@ class CoreIndexer extends AJXP_Plugin {
             if (ConfService::backgroundActionsSupported() && !ConfService::currentContextIsCommandLine()) {
                 AJXP_Controller::applyActionInBackground($repositoryId, "index", $httpVars);
                 AJXP_XMLWriter::header();
-                AJXP_XMLWriter::triggerBgAction("check_index_status", array("repository_id" => $repositoryId), sprintf($messages["core.index.8"], $nodes[0]->getPath()), true, 2);
+                AJXP_XMLWriter::triggerBgAction("check_index_status", array("repository_id" => $repositoryId), sprintf($messages["core.index.8"], SystemTextEncoding::toUTF8($nodes[0]->getPath())), true, 2);
                 if(!isSet($httpVars["inner_apply"])){
                     AJXP_XMLWriter::close();
                 }
@@ -69,16 +69,16 @@ class CoreIndexer extends AJXP_Plugin {
                 // SIMPLE FILE
                 if(!$dir){
                     try{
-                        $this->debug("Indexing - node.index ".$node->getUrl());
+                        $this->debug("Indexing - node.index ".SystemTextEncoding::toUTF8($node->getUrl()));
                         AJXP_Controller::applyHook("node.index", array($node));
                     }catch (Exception $e){
-                        $this->debug("Error Indexing Node ".$node->getUrl()." (".$e->getMessage().")");
+                        $this->debug("Error Indexing Node ".SystemTextEncoding::toUTF8($node->getUrl())." (".$e->getMessage().")");
                     }
                 }else{
                     try{
                         $this->recursiveIndexation($node);
                     }catch (Exception $e){
-                        $this->debug("Indexation of ".$node->getUrl()." interrupted by error: (".$e->getMessage().")");
+                        $this->debug("Indexation of ".SystemTextEncoding::toUTF8($node->getUrl())." interrupted by error: (".$e->getMessage().")");
                     }
                 }
 
@@ -118,7 +118,7 @@ class CoreIndexer extends AJXP_Plugin {
             AJXP_Controller::applyHook("node.index.recursive.start", array($node));
         }else{
             if($this->isInterruptRequired($repository, $user)){
-                $this->debug("Interrupting indexation! - node.index.recursive.end - ". $node->getUrl());
+                $this->debug("Interrupting indexation! - node.index.recursive.end - ". SystemTextEncoding::toUTF8($node->getUrl()));
                 AJXP_Controller::applyHook("node.index.recursive.end", array($node));
                 $this->releaseStatus($repository, $user);
                 throw new Exception("User interrupted");
@@ -127,13 +127,13 @@ class CoreIndexer extends AJXP_Plugin {
 
         if(!ConfService::currentContextIsCommandLine()) @set_time_limit(120);
         $url = $node->getUrl();
-        $this->debug("Indexing Node parent node ".$url);
+        $this->debug("Indexing Node parent node ".SystemTextEncoding::toUTF8($url));
         $this->setIndexStatus("RUNNING", str_replace("%s", SystemTextEncoding::toUTF8($node->getPath()), $messages["core.index.8"]), $repository, $user);
         if($node->getPath() != "/"){
             try {
                 AJXP_Controller::applyHook("node.index", array($node));
             } catch (Exception $e) {
-                $this->debug("Error Indexing Node ".$url." (".$e->getMessage().")");
+                $this->debug("Error Indexing Node ".SystemTextEncoding::toUTF8($url)." (".$e->getMessage().")");
             }
         }
 
@@ -144,14 +144,14 @@ class CoreIndexer extends AJXP_Plugin {
                 $childNode = new AJXP_Node(rtrim($url, "/")."/".$child);
                 $childUrl = $childNode->getUrl();
                 if(is_dir($childUrl)){
-                    $this->debug("Entering recursive indexation for ".$childUrl);
+                    $this->debug("Entering recursive indexation for ".SystemTextEncoding::toUTF8($childUrl));
                     $this->recursiveIndexation($childNode, $depth + 1);
                 }else{
                     try {
-                        $this->debug("Indexing Node ".$childUrl);
+                        $this->debug("Indexing Node ".SystemTextEncoding::toUTF8($childUrl));
                         AJXP_Controller::applyHook("node.index", array($childNode));
                     } catch (Exception $e) {
-                        $this->debug("Error Indexing Node ".$childUrl." (".$e->getMessage().")");
+                        $this->debug("Error Indexing Node ".SystemTextEncoding::toUTF8($childUrl)." (".$e->getMessage().")");
                     }
                 }
             }
@@ -160,11 +160,11 @@ class CoreIndexer extends AJXP_Plugin {
             $this->debug("Cannot open $url!!");
         }
         if($depth == 0){
-            $this->debug("End indexation - node.index.recursive.end - ". memory_get_usage(true) ."  -  ". $node->getUrl());
+            $this->debug("End indexation - node.index.recursive.end - ". memory_get_usage(true) ."  -  ". SystemTextEncoding::toUTF8($node->getUrl()));
             $this->setIndexStatus("RUNNING", "Indexation finished, cleaning...", $repository, $user);
             AJXP_Controller::applyHook("node.index.recursive.end", array($node));
             $this->releaseStatus($repository, $user);
-            $this->debug("End indexation - After node.index.recursive.end - ". memory_get_usage(true) ."  -  ". $node->getUrl());
+            $this->debug("End indexation - After node.index.recursive.end - ". memory_get_usage(true) ."  -  ". SystemTextEncoding::toUTF8($node->getUrl()));
         }
     }
 

--- a/core/src/plugins/editor.diaporama/class.ImagePreviewer.php
+++ b/core/src/plugins/editor.diaporama/class.ImagePreviewer.php
@@ -49,7 +49,7 @@ class ImagePreviewer extends AJXP_Plugin
                 header("Content-Length: 0");
                 return;
             }
-            $this->logInfo('Preview', 'Preview content of '.$file, array("files" =>$selection->getUniqueFile()));
+            $this->logInfo('Preview', 'Preview content of '.SystemTextEncoding::toUTF8($file), array("files" =>SystemTextEncoding::toUTF8($selection->getUniqueFile())));
             if (isSet($httpVars["get_thumb"]) && $httpVars["get_thumb"] == "true" && $this->getFilteredOption("GENERATE_THUMBNAIL", $repository)) {
                 $dimension = 200;
                 if(isSet($httpVars["dimension"]) && is_numeric($httpVars["dimension"])) $dimension = $httpVars["dimension"];

--- a/core/src/plugins/editor.pixlr/class.PixlrEditor.php
+++ b/core/src/plugins/editor.pixlr/class.PixlrEditor.php
@@ -112,7 +112,7 @@ class PixlrEditor extends AJXP_Plugin
             $selectedNode->loadNodeInfo();
 
             if(!is_writeable($selectedNode->getUrl())){
-                $this->logError("Pixlr Editor", "Trying to edit an unauthorized file ".$selectedNode->getUrl());
+                $this->logError("Pixlr Editor", "Trying to edit an unauthorized file ".SystemTextEncoding::toUTF8($selectedNode->getUrl()));
                 return false;
             }
 

--- a/core/src/plugins/editor.zoho/class.ZohoEditor.php
+++ b/core/src/plugins/editor.zoho/class.ZohoEditor.php
@@ -208,7 +208,7 @@ class ZohoEditor extends AJXP_Plugin
             $node->loadNodeInfo();
 
             if(!$repoWriteable || !is_writeable($node->getUrl())){
-                $this->logError("Zoho Editor", "Trying to edit an unauthorized file ".$node->getUrl());
+                $this->logError("Zoho Editor", "Trying to edit an unauthorized file ".SystemTextEncoding::toUTF8($node->getUrl()));
                 echo "NOT_ALLOWED";
                 return false;
             }

--- a/core/src/plugins/editor.zoho/class.ZohoEditor.php
+++ b/core/src/plugins/editor.zoho/class.ZohoEditor.php
@@ -129,7 +129,7 @@ class ZohoEditor extends AJXP_Plugin
 
             $node = new AJXP_Node($nodeUrl);
             AJXP_Controller::applyHook("node.read", array($node));
-            $this->logInfo('Preview', 'Posting content of '.$file.' to Zoho server', array("files" => $file));
+            $this->logInfo('Preview', 'Posting content of '.SystemTextEncoding::toUTF8($file).' to Zoho server', array("files" => SystemTextEncoding::toUTF8($file)));
 
             $extension = strtolower(pathinfo(urlencode(basename($file)), PATHINFO_EXTENSION));
             $httpClient = new http_class();
@@ -222,7 +222,7 @@ class ZohoEditor extends AJXP_Plugin
                 if (strlen($data)) {
                     file_put_contents($targetFile, $data);
                     echo "MODIFIED";
-                    $this->logInfo('Edit', 'Retrieved content of '.$node->getUrl(), array("files" => $node->getUrl()));
+                    $this->logInfo('Edit', 'Retrieved content of '.SystemTextEncoding::toUTF8($node->getUrl()), array("files" => SystemTextEncoding::toUTF8($node->getUrl())));
                     AJXP_Controller::applyHook("node.change", array(null, &$node));
                 }
             } else {
@@ -230,7 +230,7 @@ class ZohoEditor extends AJXP_Plugin
                     copy(AJXP_INSTALL_PATH."/".AJXP_PLUGINS_FOLDER."/editor.zoho/agent/files/".$id.".".$ext, $targetFile);
                     unlink(AJXP_INSTALL_PATH."/".AJXP_PLUGINS_FOLDER."/editor.zoho/agent/files/".$id.".".$ext);
                     echo "MODIFIED";
-                    $this->logInfo('Edit', 'Retrieved content of '.$node->getUrl(), array("files" => $node->getUrl()));
+                    $this->logInfo('Edit', 'Retrieved content of '.SystemTextEncoding::toUTF8($node->getUrl()), array("files" => SystemTextEncoding::toUTF8($node->getUrl())));
                     AJXP_Controller::applyHook("node.change", array(null, &$node));
                 }
             }

--- a/core/src/plugins/index.lucene/class.AjxpLuceneIndexer.php
+++ b/core/src/plugins/index.lucene/class.AjxpLuceneIndexer.php
@@ -349,7 +349,7 @@ class AjxpLuceneIndexer extends AbstractSearchEngineIndexer
     public function recursiveIndexation($url)
     {
         //print("Indexing $url \n");
-        $this->logDebug("Indexing content of folder ".$url);
+        $this->logDebug("Indexing content of folder ".SystemTextEncoding::toUTF8($url));
         if (ConfService::currentContextIsCommandLine() && $this->verboseIndexation) {
             print("Indexing content of ".$url."\n");
         }
@@ -362,7 +362,7 @@ class AjxpLuceneIndexer extends AbstractSearchEngineIndexer
                 if (ConfService::currentContextIsCommandLine() && $this->verboseIndexation) {
                     print("Indexing node ".$newUrl."\n");
                 }
-                $this->logDebug("Indexing Node ".$newUrl);
+                $this->logDebug("Indexing Node ".SystemTextEncoding::toUTF8($newUrl));
                 try {
                     $newNode = new AJXP_Node($newUrl);
                     $this->updateNodeIndex(null, $newNode, false, true);
@@ -371,12 +371,12 @@ class AjxpLuceneIndexer extends AbstractSearchEngineIndexer
                     if (ConfService::currentContextIsCommandLine() && $this->verboseIndexation) {
                         print("Error indexing node ".$newUrl." (".$e->getMessage().") \n");
                     }
-                    $this->logDebug("Error Indexing Node ".$newUrl." (".$e->getMessage().")");
+                    $this->logDebug("Error Indexing Node ".SystemTextEncoding::toUTF8($newUrl)." (".$e->getMessage().")");
                 }
             }
             closedir($handle);
         } else {
-            $this->logDebug("Cannot open $url!!");
+            $this->logDebug("Cannot open ".SystemTextEncoding::toUTF8($url)." !!");
         }
     }
 
@@ -435,9 +435,9 @@ class AjxpLuceneIndexer extends AbstractSearchEngineIndexer
             if(file_exists($node->getUrl())){
                 $this->createIndexedDocument($node, $index);
             }
-            $this->logDebug(__FILE__, "Indexation passed ".$node->getUrl());
+            $this->logDebug(__FILE__, "Indexation passed ".SystemTextEncoding::toUTF8($node->getUrl()));
         } catch (Exception $e){
-            $this->logError(__FILE__, "Lucene indexation failed for ".$node->getUrl()." (".$e->getMessage().")");
+            $this->logError(__FILE__, "Lucene indexation failed for ".SystemTextEncoding::toUTF8($node->getUrl())." (".$e->getMessage().")");
         }
     }
 
@@ -758,7 +758,7 @@ class AjxpLuceneIndexer extends AbstractSearchEngineIndexer
             try{
                 $index = Zend_Search_Lucene::open($iPath);
             }catch (Zend_Search_Lucene_Exception $se){
-                $this->logError(__FUNCTION__, "Error while trying to load lucene index at path ".$iPath."! Maybe a permission issue?");
+                $this->logError(__FUNCTION__, "Error while trying to load lucene index at path ".SystemTextEncoding::toUTF8($iPath)."! Maybe a permission issue?");
                 throw $se;
             }
         } else {
@@ -769,7 +769,7 @@ class AjxpLuceneIndexer extends AbstractSearchEngineIndexer
             try{
                 $index = Zend_Search_Lucene::create($iPath);
             }catch (Zend_Search_Lucene_Exception $se){
-                $this->logError(__FUNCTION__, "Error while trying to create lucene index at path ".$iPath."! Maybe a permission issue?");
+                $this->logError(__FUNCTION__, "Error while trying to create lucene index at path ".SystemTextEncoding::toUTF8($iPath)."! Maybe a permission issue?");
                 throw $se;
             }
         }

--- a/core/src/plugins/meta.simple_lock/class.SimpleLockManager.php
+++ b/core/src/plugins/meta.simple_lock/class.SimpleLockManager.php
@@ -115,7 +115,7 @@ class SimpleLockManager extends AJXP_AbstractMetaSource
      */
     public function checkFileLock($node)
     {
-        $this->logDebug("SHOULD CHECK LOCK METADATA FOR ", $node->getLabel());
+        $this->logDebug("SHOULD CHECK LOCK METADATA FOR ", SystemTextEncoding::toUTF8($node->getLabel()));
         $lock = $this->metaStore->retrieveMetadata(
            $node,
            SimpleLockManager::METADATA_LOCK_NAMESPACE,


### PR DESCRIPTION
All message in table ajxp_log truncated (column "params"), if accent in path or file name (win OS)
=> this mean the same issue in pydio =>settings => display Logs