### PR TITLE
Redis: avoid conflict in Doctrine

### DIFF
--- a/core/src/plugins/cache.doctrine/ext/PydioRedisCache.php
+++ b/core/src/plugins/cache.doctrine/ext/PydioRedisCache.php
@@ -35,7 +35,7 @@ class PydioRedisCache extends \Doctrine\Common\Cache\RedisCache implements Patte
     protected $internalNamespaceVersion;
 
 
-    public function setRedis($redis){
+    public function setRedis(Redis $redis){
         parent::setRedis($redis);
         $this->internalRedis = $redis;
     }


### PR DESCRIPTION
On 6.4.2 after an upgrade to PHP7 there was this error:
```
Declaration of Pydio\Plugins\Cache\Doctrine\Ext\PydioRedisCache::setRedis($redis) should be compatible with Doctrine\Common\Cache\RedisCache::setRedis(Redis $redis)
```

see
https://github.com/pydio/pydio-core/issues/1201

and
https://pydio.com/forum/f/topic/upgrade-version-6-4-2-error-redis/#post-104032

and
https://pydio.com/forum/f/topic/6-4-2-problem-w-redis-cache-after-upgrade-to-php7/#post-104033