### PR TITLE
Option for downloading zip files on the fly (second patch)

### DIFF
--- a/core/src/plugins/access.fs/manifest.xml
+++ b/core/src/plugins/access.fs/manifest.xml
@@ -14,6 +14,7 @@
         <param name="DATA_TEMPLATE" type="string" label="CONF_MESSAGE[Data template]" description="CONF_MESSAGE[Path to a directory on the filesystem whose content will be copied to the repository the first time it is loaded.]" default=""/>
         <global_param name="PROBE_REAL_SIZE" type="boolean" label="CONF_MESSAGE[Real Size Probing]" description="CONF_MESSAGE[Use system command line to get the filesize instead of php built-in function (fixes the 2Go limitation)]" default="false"/>
         <global_param name="USE_POSIX" type="boolean" label="CONF_MESSAGE[Use POSIX]" description="CONF_MESSAGE[Use php POSIX extension to read files permissions. Only works on *nix systems.]" default="false"/>
+        <global_param name="ZIP_ON_THE_FLY" type="boolean" label="CONF_MESSAGE[Zip downloading files on the fly]" description="CONF_MESSAGE[Directly write the zip file to an output stream which is connected to the user's browser.]" default="false"/>
         <global_param group="MIXIN_MESSAGE[Metadata and indexation]" name="DEFAULT_METASOURCES" type="string" label="MIXIN_MESSAGE[Default Metasources]" description="MIXIN_MESSAGE[Comma separated list of metastore and meta plugins, that will be automatically applied to all repositories created with this driver]" mandatory="false" default="metastore.serial,meta.watch,meta.syncable,meta.filehasher,index.lucene"/>
 	</server_settings>
 	<class_definition filename="plugins/access.fs/FsAccessDriver.php" classname="Pydio\Access\Driver\StreamProvider\FS\FsAccessDriver"/>


### PR DESCRIPTION
So pydio can directly write the zip file to an output stream which is
connected to the user's browser without creating any temporary files.

Second attempt to merge feature of  #1172.