### PR TITLE
Fix problem with non-ascii filenames in zip

### DIFF
--- a/core/src/plugins/access.fs/FsAccessDriver.php
+++ b/core/src/plugins/access.fs/FsAccessDriver.php
@@ -2380,10 +2380,6 @@ class FsAccessDriver extends AbstractAccessDriver implements IAjxpWrapperProvide
                 $filePaths[] = [PCLZIP_ATT_FILE_NAME => $realFile];
             } else {
                 $shortName = $node->getLabel();
-                if(!empty($zipEncoding)){
-                    $test = iconv(TextEncoder::getEncoding(), $zipEncoding, $shortName);
-                    if($test !== false) $shortName = $test;
-                }
                 $filePaths[] = [PCLZIP_ATT_FILE_NAME => $realFile,
                                     PCLZIP_ATT_FILE_NEW_SHORT_NAME => $shortName];
             }
@@ -2400,7 +2396,7 @@ class FsAccessDriver extends AbstractAccessDriver implements IAjxpWrapperProvide
             }
             $search = $header["filename"];
             if(!empty($zipEncoding)){
-                $test = iconv($fsEncoding, $zipEncoding, $header["stored_filename"]);
+                $test = iconv($fsEncoding, $zipEncoding.'//TRANSLIT', $header["stored_filename"]);
                 if($test !== false){
                     $header["stored_filename"] = $test;
                 }


### PR DESCRIPTION
First of all, iconv previously was called twice on every packed file.
First call of iconv was removed due to partial convert of only basename.
Second call of iconv was appended with key `'//TRANSLIT'`, which decodes unicode chars to their equivalents in selected codepage. This addition fixes unsuccesful codepage conversions on many filenames.
