### PR TITLE
Add Polr to URL shortener APIs

### DIFF
--- a/core/src/plugins/shorten.multi/MultiShortener.php
+++ b/core/src/plugins/shorten.multi/MultiShortener.php
@@ -170,6 +170,31 @@ class MultiShortener extends Plugin
                     return $shorturl;
                 }
                 break;
+            case 5:
+                if (!isSet($type["POLR_DOMAIN"])) {
+                    $this->logError("Config", "polr Shortener : you must set the domain name");
+                    return null;
+                }
+                if (!isSet($type["POLR_APIKEY"])) {
+                    $this->logError("Config", "polr Shortener : you must set the api key");
+                    return null;
+                }
+                $polr_domain = $type["POLR_DOMAIN"];
+                $polr_api = $type["POLR_APIKEY"];
+                $polr = 'http://'.$polr_domain.'/api/v2/action/shorten?key='.$polr_api.'&url='.$url;
+                $response = FileHelper::getRemoteContent($polr);
+                if (isSet($response)) {
+                    $shorturl = $response;
+                    if ($useidn) {
+                        // WARNING: idn_to_utf8 requires php-idn module.
+                        // WARNING: http_build_url requires php-pecl-http module.
+                        $purl = parse_url($shorturl);
+                        $purl['host'] = idn_to_utf8($purl['host']);
+                        $shorturl = http_build_url($purl);
+                    }
+                    return $shorturl;
+                }
+                break;
 
             default:
                 break;

--- a/core/src/plugins/shorten.multi/manifest.xml
+++ b/core/src/plugins/shorten.multi/manifest.xml
@@ -27,6 +27,10 @@
 		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="YOURLS_DOMAIN" type="string" label="CONF_MESSAGE[Short domain]" description="CONF_MESSAGE[Yourls domain]" mandatory="false"/>
 		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="YOURLS_APIKEY" type="string" label="CONF_MESSAGE[API Key]" description="CONF_MESSAGE[API Key]" mandatory="false"/>
 		<global_param group_switch_name="shorten_type" group_switch_label="yourls" group_switch_value="yourls" name="YOURLS_USEIDN" type="boolean" label="CONF_MESSAGE[Use IDN]" description="CONF_MESSAGE[Use IDN]" mandatory="false" default="false"/>
+        <global_param group_switch_name="shorten_type" group_switch_label="polr" group_switch_value="polr" name="shorten_type" type="hidden" label="" description="" mandatory="false" default="5"/>
+        <global_param group_switch_name="shorten_type" group_switch_label="polr" group_switch_value="polr" name="POLR_DOMAIN" type="string" label="CONF_MESSAGE[Short domain]" description="CONF_MESSAGE[Short domain]" mandatory="false"/>
+        <global_param group_switch_name="shorten_type" group_switch_label="polr" group_switch_value="polr" name="POLR_APIKEY" type="string" label="CONF_MESSAGE[API Key]" description="CONF_MESSAGE[API Key]" mandatory="false"/>
+
     </server_settings>
 	<registry_contributions>
         <hooks>


### PR DESCRIPTION
This adds the selfhosted URL shortener [Polr](https://github.com/cydrobolt/polr) to the MultiShortener's supported APIs.

The API is very similar to YOURLS, so most of the code is the same, but it still required changes.