### PR TITLE
Fix issue #1259: Zip on-the-fly option creates 0-sized empty files

### DIFF
--- a/core/src/plugins/access.fs/FsAccessDriver.php
+++ b/core/src/plugins/access.fs/FsAccessDriver.php
@@ -662,6 +662,7 @@ class FsAccessDriver extends AbstractAccessDriver implements IAjxpWrapperProvide
                     if ($this->getContextualOption($ctx, "ZIP_ON_THE_FLY")) {
                         // Make a zip on the fly and send stream as download
                     	$response = HTMLWriter::responseWithAttachmentsHeaders($response, $localName, null, false, false);
+                    	$response = $response->withoutHeader("Content-Length");
                         $asyncReader = new \Pydio\Core\Http\Response\AsyncResponseStream(function () use ($selection, $dir) {
                             session_write_close();
                             restore_error_handler();


### PR DESCRIPTION
Also for comments on #1247