### PR TITLE
fix mixed (plain text/xml) response leading to unknown parsing error

### DIFF
--- a/core/src/plugins/core.auth/AbstractAuthDriver.php
+++ b/core/src/plugins/core.auth/AbstractAuthDriver.php
@@ -99,8 +99,7 @@ class AbstractAuthDriver extends Plugin
                     print "PASS_ERROR";
                     break;
                 }
-                header("Content-Type:text/plain");
-                print "SUCCESS";
+                $responseInterface = new TextResponse("SUCCESS");
 
                 break;
 


### PR DESCRIPTION
See [Forum discussion](https://pydio.com/forum/f/topic/unknown-parsing-error-on-pass-change-after-login/#post-107192).