### PR TITLE
Added option for Lucene Search to search only the current folder and subfolders

### DIFF
--- a/core/src/conf/RELEASE_NOTE
+++ b/core/src/conf/RELEASE_NOTE
@@ -2,29 +2,38 @@ Pydio ##VERSION_NUMBER## Release Note
 
 7.0.4 is a bugfix and security release for 7 branch.
 
-Make sure checking db version test does not break everything (if there is a missing table for example). (details)
-Fix throw error when accessing to prohibited path on smb wsp (details)
-Fix EncFS and caching issues (details)
-Optim: make sure clear cache is called deferred. (details)
-Do not use applyHook but load session manager directly instead for performances. (details)
-Mq.serial: make $channels static variable as in mq.sql (details)
-Add an option to disable nodes caching (details)
-Add ldap support AD memberof values in nested group (details)
-Fix EncFS (details)
-Make sure that unserialized object is a Notification instance (details)
-Switch lite version to full version (details)
-Fix webDAV upload events. Should fix #1317 and fix #1318 (details)
-Replace check for bypass_pwd by check on empty $pwd variable. Should fix #1316, please confirm (details)
-Test USE_SESSION_CREDENTIALS value, not just isset(). Should be the real cause of #1316 (details)
-Close session on possibly long requests that may block the UI (details)
-Adding local cache per instance to MemorySafe and removing time limit on nodes cache (details)
-Adding interval for the Zoho Editor when in the minisite (details)
-Fix #1319, enable Copy action on readonly files. (details)
-Making sure we don't break previous usage (details)
-Update tutorial videos. Open panel by default for the first connexion. (details)
-Fix events forwarding for one-doc minisite (use ContentFilter instead of relative path re-compute). Zoho send a create event instead of a content event. (details)
-Fix for s3 shares (details)
-Typo error (details)
+Make sure checking db version test does not break everything (if there is a missing table for example).
+Fix throw error when accessing to prohibited path on smb wsp
+Fix EncFS and caching issues
+Optim: make sure clear cache is called deferred.
+Do not use applyHook but load session manager directly instead for performances.
+Mq.serial: make $channels static variable as in mq.sql
+Add an option to disable nodes caching
+Add ldap support AD memberof values in nested group
+Fix EncFS
+Make sure that unserialized object is a Notification instance
+Switch lite version to full version
+Fix webDAV upload events. Should fix #1317 and fix #1318
+Replace check for bypass_pwd by check on empty $pwd variable. Should fix #1316, please confirm
+Test USE_SESSION_CREDENTIALS value, not just isset(). Should be the real cause of #1316
+Close session on possibly long requests that may block the UI
+Adding local cache per instance to MemorySafe and removing time limit on nodes cache
+Adding interval for the Zoho Editor when in the minisite
+Fix #1319, enable Copy action on readonly files.
+Making sure we don't break previous usage
+Update tutorial videos. Open panel by default for the first connexion.
+Fix events forwarding for one-doc minisite (use ContentFilter instead of relative path re-compute). Zoho send a create event instead of a content event.
+Fix for s3 shares
+Typo error
+Fix #1322 by triming userId whitespaces.
+Missing logs when upload via pluploader. Fix #1321
+Remove double urldecode, creating "+" issues in Rest API.
+Typo in roles manager could lead to group admin seeing unauthorized workspaces
+Add an optional parameter to enable links in digest email.
+Fix notifications when registering on a "publicly visible" share.
+Fix non-deleting alerts
+Try to make a better error reporting when exception fails because response already sent or logger fails.
+Fix closing of videos tutorials
 
 7.0.3 is a bugfixes for 7.0.2. Particularly, some issues were introduced with the Session Credentials mechanism.
 

--- a/core/src/plugins/gui.ajax/res/js/ui/prototype/class.SearchEngine.js
+++ b/core/src/plugins/gui.ajax/res/js/ui/prototype/class.SearchEngine.js
@@ -910,6 +910,8 @@ Class.create("SearchEngine", AjxpPane, {
             connexion.discrete = true;
             connexion.addParameter('get_action', 'search');
             connexion.addParameter('query', this.crtText);
+            connexion.addParameter('dir', currentFolder);
+
             if(limit && limit !== -1){
                 connexion.addParameter('limit', limit);
             }

--- a/core/src/plugins/index.lucene/manifest.xml
+++ b/core/src/plugins/index.lucene/manifest.xml
@@ -8,6 +8,7 @@
         </resources>
     </client_settings>
     <server_settings>
+        <param name="folder_search" type="boolean" label="CONF_MESSAGE[Search in current folder and subfolders only]" description="CONF_MESSAGE[When enabled, the searches are performed only in the current folder and subfolders. If disabled, the search always pertains to the whole workspace.]" mandatory="true" default="false"/>
         <param name="index_content" type="boolean" label="CONF_MESSAGE[Index Content]" description="CONF_MESSAGE[Parses the file when possible and index its content (see plugin global options)]" mandatory="true" default="false"/>
         <param name="index_meta_fields" type="string" label="CONF_MESSAGE[Index Meta Fields]" description="CONF_MESSAGE[Which additionnal fields to index and search]" mandatory="false" />
         <param name="repository_specific_keywords" type="string" label="CONF_MESSAGE[Repository keywords]" description="CONF_MESSAGE[If your repository path is defined dynamically by specific keywords like AJXP_USER, or your own, mention them here.]" mandatory="false"/>

--- a/core/src/plugins/index.lucene/resources/i18n/conf/en.php
+++ b/core/src/plugins/index.lucene/resources/i18n/conf/en.php
@@ -45,4 +45,6 @@ $mess=array(
 "Automatically append a * after the user query to make the search broader" => "Automatically append a * after the user query to make the search broader",
 "Hide 'My Shares'" => "Hide 'My Shares'",
 "Hide My Shares section in the Orbit theme GUI." => "Hide My Shares section in the Orbit theme GUI.",
+"Search in current folder and subfolders only" => "Search in current folder and subfolders only",
+"When enabled, the searches are performed only in the current folder and subfolders. If disabled, the search always pertains to the whole workspace." => "When enabled, the searches are performed only in the current folder and subfolders. If disabled, the search always pertains to the whole workspace.",
 );


### PR DESCRIPTION
I would like to use Pydio as for digital asset management. There a few features missing that I believe are needed. The ability to search only the current folder and its subfolders is one of them. I tried to implement this for index.lucene. There is an option in workspace features where one can enable the search in current folder and subfolders (as opposed to the global workspace-wide search). The solution uses an additional field in the Lucene index, thus reindexing is needed after the update.
