### PR TITLE
Run starttls before trying to bind on LDAP

### DIFF
--- a/core/src/plugins/auth.ldap/LdapAuthDriver.php
+++ b/core/src/plugins/auth.ldap/LdapAuthDriver.php
@@ -218,9 +218,6 @@ class LdapAuthDriver extends AbstractAuthDriver
             if ($this->ldapconn == null) {
                 $this->logError(__FUNCTION__, 'LDAP Server connexion could NOT be established');
             }
-            if ($this->ldapconn !== null && isSet($this->options["LDAP_PROTOCOL"]) && $this->options["LDAP_PROTOCOL"] === 'starttls') {
-                ldap_start_tls($this->ldapconn);
-            }
         }
     }
 
@@ -239,6 +236,9 @@ class LdapAuthDriver extends AbstractAuthDriver
         if ($ldapconn) {
             $this->logDebug(__FUNCTION__, 'ldap_connect(' . $this->ldapUrl . ',' . $this->ldapPort . ') OK');
             ldap_set_option($ldapconn, LDAP_OPT_PROTOCOL_VERSION, 3);
+            if (isSet($this->options["LDAP_PROTOCOL"]) && $this->options["LDAP_PROTOCOL"] === 'starttls'){
+                ldap_start_tls($ldapconn);
+            }
             //ldap_set_option( $ldapconn, LDAP_OPT_REFERRALS, 0 );
 
             if ($this->ldapAdminUsername === null) {


### PR DESCRIPTION
Followup of #1248 starttls should be done earlier, in LDAP_Connect, instead of startConnection. The reason is that we bind in LDAP_Connect, and correctly configured LDAP servers only allows binds if the connection is secured, so, after starttls ran