### PR TITLE
Fix broken WebDAV digest auth

### DIFF
--- a/core/src/core/src/pydio/Core/Http/Dav/AuthBackendDigest.php
+++ b/core/src/core/src/pydio/Core/Http/Dav/AuthBackendDigest.php
@@ -70,17 +70,22 @@ class AuthBackendDigest extends Sabre\DAV\Auth\Backend\AbstractDigest
      */
     public function getDigestHash($realm, $username)
     {
-        try{
+        try {
             $user = UsersService::getUserById($username);
-        }catch (UserNotFoundException $e){
+        } catch (UserNotFoundException $e) {
             throw new Sabre\DAV\Exception\NotAuthenticated();
         }
         $webdavData = $user->getPref("AJXP_WEBDAV_DATA");
-        $active = ConfService::getGlobalConf("WEBDAV_ACTIVE_ALL");
-        if(!empty($webdavData) && isSet($webdavData["ACTIVE"]) && $webdavData["ACTIVE"] === false){
-            $active = false;
+        $globalActive = ConfService::getGlobalConf("WEBDAV_ACTIVE_ALL");
+        // If the user has no WebDAV Data, no WebDAV can be used
+        if (empty($webdavData)) {
+            return false;
         }
-        if (!$active || (!isSet($webdavData["PASS"]) && !isset($webdavData["HA1"]) ) ) {
+        // If WebDAV is not globally active and also inactive in user prefs
+        if (!$globalActive && (isSet($webdavData["ACTIVE"]) && $webdavData["ACTIVE"] === false)){
+            return false;
+        }
+        if (!isSet($webdavData["PASS"]) && !isset($webdavData["HA1"])) {
             return false;
         }
         if (isSet($webdavData["HA1"])) {
@@ -89,7 +94,6 @@ class AuthBackendDigest extends Sabre\DAV\Auth\Backend\AbstractDigest
             $pass = $this->_decodePassword($webdavData["PASS"], $username);
             return md5("{$username}:{$realm}:{$pass}");
         }
-
     }
 
     /**


### PR DESCRIPTION
Authenticating via digest auth was not possible if the following
conditions were met:

 - Enable WebDAV --> On
 - Enable for all users --> Off
 - My Account - Activate WebDAV shares --> On

In this case `getDigestHash()` always returns `false`. Because of
this, authentication always fails.

This issue can be reproduced on a fresh installation of Pydio 7.0.4 and 8.0.0.