### PR TITLE
Use baseUrl before calling action clear_cache_key

### DIFF
--- a/core/src/plugins/core.cache/AbstractCacheDriver.php
+++ b/core/src/plugins/core.cache/AbstractCacheDriver.php
@@ -394,9 +394,10 @@ abstract class AbstractCacheDriver extends Plugin
     public function __destruct()
     {
         if(count($this->httpDeletion)){
+            $baseUrl = ApplicationState::detectServerURL(true);
             $client = $this->getHttpClient();
             if(empty($client)) return;
-            $client->post('/?get_action=clear_cache_key', [
+            $client->post($baseUrl.'/?get_action=clear_cache_key', [
                 'body' => [
                     'data' => json_encode($this->httpDeletion)
                 ]


### PR DESCRIPTION
When calling indexing action using CLI, following error appears:
Please enter the password: 
*****************************
Current User is 'admin'
*****************************
Applying action 'index' on workspace Anonymous Samba Share (2ddbecd39691a01afbfab6e1aae7eec9)
<?xml version="1.0" encoding="UTF-8"?><tree ><message type="SUCCESS">Indexation launched</message><consume_channel/></tree>

PHP Fatal error:  Uncaught exception 'GuzzleHttp\Exception\ClientException' with message 'Client error response [url] http://192.168.2.51/?get_action=clear_cache_key [status code] 404 [reason phrase] Not Found' in /usr/share/pydio/core/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:89
Stack trace:
#0 /usr/share/pydio/core/vendor/guzzlehttp/guzzle/src/Subscriber/HttpError.php(33): GuzzleHttp\Exception\RequestException::create(Object(GuzzleHttp\Message\Request), Object(GuzzleHttp\Message\Response))
#1 /usr/share/pydio/core/vendor/guzzlehttp/guzzle/src/Event/Emitter.php(108): GuzzleHttp\Subscriber\HttpError->onComplete(Object(GuzzleHttp\Event\CompleteEvent), 'complete')
#2 /usr/share/pydio/core/vendor/guzzlehttp/guzzle/src/RequestFsm.php(91): GuzzleHttp\Event\Emitter->emit('complete', Object(GuzzleHttp\Event\CompleteEvent))
#3 /usr/share/pydio/core/vendor/guzzlehttp/guzzle/src/RequestFsm.php(132): GuzzleHttp\RequestFsm->__invoke(Object(GuzzleHttp\Transaction))
#4 /usr/share/pydio/core/vendor/react/promise/src/Fulfill in /usr/share/pydio/core/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php on line 89

Because baseUrl is not used.

With baseUrl detected and used, no more error and indexation works.

Best regards,
Edouard