### PR TITLE
video.js * does not work

### DIFF
--- a/core/src/plugins/editor.video/package.json
+++ b/core/src/plugins/editor.video/package.json
@@ -20,6 +20,6 @@
     "lodash": "*",
     "react": "15.4.2",
     "react-dom": "15.4.2",
-    "video.js": "*"
+    "video.js": "5.20.5"
   }
 }


### PR DESCRIPTION
video.js 5.20.5 was the latest working version for Pydio. Maybe not the ideal fix, but should work until a better one is found.