### PR TITLE
Fixed issue with non-ASCII-characters

### DIFF
--- a/core/src/index.php
+++ b/core/src/index.php
@@ -22,6 +22,8 @@
  * Will dispatch the actions on the plugins.
  */
 
+setlocale(LC_ALL, "en_US.utf8");  //Set locale to UTF-8 to avoid stripping of non-ASCII-characters (e.g. in filenames).
+
 use Pydio\Core\Http\TopLevelRouter;
 
 include_once("base.conf.php");


### PR DESCRIPTION
non-ASCII-characters (ä,ö,ü,ß,...) had been stripped from files by escapeshellarg(), causing errors within av-plugin while scanning files that contain such characters.
This will fix this situation.